### PR TITLE
Nouveau compte pas de création de redirection

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,11 +165,10 @@ function userInfos(name, is_current_user) {
         email_infos == undefined &&
         (is_current_user || redirections.length === 0);
 
-      // On peut créer une redirection que si la page fiche github existe, que le compte n'existe pas et qu'il n'y a aucun redirection. (sauf l'utilisateur(trice) connecté qui peut créer ces propres redirections)
+      // On peut créer une redirection si la page fiche github existe et que l'on est l'utilisateur(trice) connecté pour créer ces propres redirections.
       const can_create_redirection =
         user_infos != undefined &&
-        (is_current_user ||
-          (redirections.length === 0 && email_infos == undefined));
+         is_current_user;
 
       const result = {
         email_infos,

--- a/views/user.mustache
+++ b/views/user.mustache
@@ -36,8 +36,6 @@
  <fieldset>
   <legend>Créer le compte mail</legend>
   <label>Envoyer le mot de passe à cette adresse mail : <br> <input name="to_email" type="email" required></label><br>
-  <label><input type="checkbox" name="create_redirection" value="true"> Créer aussi une redirection vers cette adresse</label><br>
-  <input type="checkbox" name="keep_copy" value="true"> Garder une copie des emails en cas de redirection</label><br>
   <button>Créer un compte</button>
   </fieldset>
 </form>


### PR DESCRIPTION
L'idée est de nudger les gens a créé des comptes.

Les redirections peuvent être créé dans un second temps si l'utilisateur veut une redirection.