### PR TITLE
Ajustement de l'option debug de nodemailer

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const config = {
 };
 
 const mailTransport = nodemailer.createTransport({
-  debug: process.env.MAIL_DEBUG || false,
+  debug: process.env.MAIL_DEBUG === 'true',
   service: process.env.MAIL_SERVICE,
   auth: {
     user: process.env.MAIL_USER,


### PR DESCRIPTION
Permet de s'assurer que l'option '[debug](https://nodemailer.com/smtp/#debug-options)' envoyé à nodemailer dans la fonction _createTransport_ est un boolean.