### PR TITLE
Updates the node image used with Docker to LTS (#73)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.16
+FROM node:lts
 
 WORKDIR /app
 


### PR DESCRIPTION
Ce PR met à jour l'image node utilisé pour notre Dockerfile. La version précédente se basait sur l'image _node 8.16_, qui n'est plus supporté depuis fin 2019.  

Ceci permet d'utiliser en dev la même version de Node qu'en prod ([Scalingo utilise le dernier LTS](https://doc.scalingo.com/languages/nodejs/start#specifying-a-nodejs-version)) ainsi que de débloquer les PR dependabot qui ne passent pas la CircleCI à cause de la version non-supportée de node utilisé actuellement, par exemple #60 :

```
prettier@2.0.5: The engine "node" is incompatible with this module. Expected version ">=10.13.0". Got "8.16.2"
```
