### PR TITLE
Ajoute au readme des options de mock servers. Améliore la mise en format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,47 +3,44 @@ Le secrétariat de l’incubateur
 
 ## Dev de l'app de secrétariat
 
+### Variables d'environnement
+
 - Variables d'environnement nécessaires :
-   - OVH_APP_KEY
-   - OVH_APP_SECRET
-   - OVH_CONSUMER_KEY
-   - SESSION_SECRET (clé de 32 caractère aléatoires, important en prod)
-   - MAIL_SERVICE (service géré par nodemailer, `mailjet` est dispo)
-   - MAIL_USER
-   - MAIL_PASS
-   - SECURE (true si https sinon false)
-   - SLACK_WEBHOOK_URL (adresse d'envoit des notifs : https://hooks.slack.com/services/...)
-- Récupérer les dépendances avec npm
-- Lancer l'app : `npm run dev`
-- Ouvrir `http://localhost:8100` (8100 est le port par défaut, vous pouvez le changer avec la variable d'env PORT)
+   - `OVH_APP_KEY` - [Obtenir les credentials OVH pour débugger](#Générer-clé-API-OVH)
+   - `OVH_APP_SECRET`
+   - `OVH_CONSUMER_KEY`
+   - `SESSION_SECRET` - Clé de 32 caractère aléatoires, important en prod
+   - `MAIL_SERVICE` - Service [géré par nodemailer](https://nodemailer.com/smtp/well-known/) ([Débugger SMTP en local](#Debug-avec-le-serveur-SMTP-Maildev))
+   - `MAIL_USER`
+   - `MAIL_PASS`
+   - `SECURE` - _true_ si https sinon _false_
+   - `SLACK_WEBHOOK_URL` - Adresse d'envoi des notifications Slack - par ex. : _https://hooks.slack.com/services/..._ ([Débugger sans Slack](#Debug-sans-notifications-Slack))
 
-### Debug avec un autre domaine OVH
-- Configurer la variable d'environnement SECRETARIAT_DOMAIN (par défaut à beta.gouv.fr)
+- Variables d'environnement optionnels :
+   - `SECRETARIAT_DOMAIN` - Domaine OVH à utiliser ([Débugger avec un autre domaine OVH](#Debug-avec-un-autre-domaine-OVH))
+   - `USERS_API` - API User à utiliser ([Débugger avec une autre API](#Debug-avec-une-autre-API-utilisateur))
 
-### Debug avec une autre API utilisateur
-- Configurer la variable d'environnement USERS_API (par défaut à https://beta.gouv.fr/api/v1.6/authors.json)
+### Lancer en mode développement
 
-### Debug avec le serveur SMTP Maildev
+```
+» npm install # Récupère les dépendances
+» npm run dev
+   ...
+   Running on port: 8100
+```
+L'application sera disponible sur `http://localhost:8100` (8100 est le port par défaut, vous pouvez le changer avec la variable d'env `PORT`)
 
-[Maildev](http://maildev.github.io/maildev/) est un serveur SMTP avec une interface web conçus pour le développement et les tests.
+### Lancer en mode production
 
-Une fois [installé](http://maildev.github.io/maildev/#install) et lancé, il suffit de mettre la variable d'environnement `MAIL_SERVICE` à `maildev` pour l'utiliser. `MAIL_USER` et `MAIL_PASS` ne sont pas nécessaires.
+```
+» npm run start
+   ...
+   Running on port: 8100
+```
 
-Tous les emails envoyés par le code du secrétariat seront visibles depuis l'interface web de Maildev.
+### Générer clé API OVH
 
-## Script pour faire des taches en local
-
-# Générer le graphe des redirections emails
-
-- Configurer les variables d'environnements : OVH_APP_KEY, OVH_APP_SECRET et OVH_CONSUMER_KEY (Avec une clé aillant un accès aux emails)
-- Lancer le script : `node ./scripts/export_redirections_to_dot.js > redirections.dot`
-- Lancer graphviz : `dot -Tpdf redirections.dot -o redirections.pdf` (Format disponible : svg,png, ...)
-
-# Supprimer une redirection
-- Configurer les variables d'environnements : OVH_APP_KEY, OVH_APP_SECRET et OVH_CONSUMER_KEY (Avec une clé aillant un accès aux emails)
-- Lancer le script : `node ./scripts/delete_redirections.js from@beta.gouv.fr to@example.com`
-
-## Générer clé API OVH
+_Si vous n'avez pas les droits pour générer les credentials OVH, postez un message sur [#incubateur-amélioration-secretariat](https://startups-detat.slack.com/archives/C017J6CUN2V)._
 
 Lien : https://eu.api.ovh.com/createToken/
 
@@ -64,17 +61,48 @@ POST /email/domain/beta.gouv.fr/mailingList/*/subscriber
 DELETE /email/domain/beta.gouv.fr/mailingList/*/subscriber/*
 ```
 
-## Dev docker-compose
+### Debug avec le serveur SMTP Maildev
+
+[Maildev](http://maildev.github.io/maildev/) est un serveur SMTP avec une interface web conçus pour le développement et les tests.
+
+Une fois [installé](http://maildev.github.io/maildev/#install) et lancé, il suffit de mettre la variable d'environnement `MAIL_SERVICE` à `maildev` pour l'utiliser. `MAIL_USER` et `MAIL_PASS` ne sont pas nécessaires.
+
+Tous les emails envoyés par le code du secrétariat seront visibles depuis l'interface web de Maildev.
+
+### Debug sans notifications Slack
+
+Pour certaines actions, le secrétariat envoie une notification Slack. En local, vous pouvez mettre la variable d'environnement `SLACK_WEBHOOK_URL` à un service qui reçoit des requêtes POST et répond avec un `200 OK` systématiquement.
+
+[Beeceptor](https://beeceptor.com/) permet de le faire avec une interface en ligne sans besoin de télécharger quoi que ce soit.
+
+Sinon, certains outils gratuits comme [Mockoon](https://mockoon.com/) ou [Postman](https://www.postman.com/) permettent de créer des serveurs mock facilement aussi ([Guide Postman](https://learning.postman.com/docs/designing-and-developing-your-api/mocking-data/setting-up-mock/#creating-mock-servers-in-app)).
+
+### Debug avec un autre domaine OVH
+
+Lorsqu'on utilise un autre domaine OVH (par exemple, un domain bac-à-sable pour le développement), la variable `SECRETARIAT_DOMAIN` doit être renseignée. Par défaut, le domaine est `beta.gouv.fr`.
+
+### Debug avec une autre API utilisateur
+Configurer la variable d'environnement `USERS_API` (par défaut à https://beta.gouv.fr/api/v1.6/authors.json)
+
+
+## Scripts pour faire des taches en local
+
+### Générer le graphe des redirections emails
+
+- Configurer les variables d'environnements : `OVH_APP_KEY`, `OVH_APP_SECRET` et `OVH_CONSUMER_KEY` (Avec une clé ayant un accès aux emails)
+- Lancer le script : `node ./scripts/export_redirections_to_dot.js > redirections.dot`
+- Lancer graphviz : `dot -Tpdf redirections.dot -o redirections.pdf` (Format disponible : svg,png, ...)
+
+### Supprimer une redirection
+- Configurer les variables d'environnements : `OVH_APP_KEY`, `OVH_APP_SECRET` et `OVH_CONSUMER_KEY` (Avec une clé ayant un accès aux emails)
+- Lancer le script : `node ./scripts/delete_redirections.js from@beta.gouv.fr to@example.com`
+
+### Dev docker-compose
 
 - Récupéré les dépendences : `docker-compose run web npm install`
 - Lancer le service : `docker-compose up`
 - Lancer les tests : `docker-compose run web npm test`
 
-## Dev docker sans docker-compose
+### Dev docker sans docker-compose
 - Exemple pour développer dans un container :
 	- `docker run --rm --env-file ../.env.secretariat.dev -v $(pwd):/app -w /app -ti -p 8100 node /bin/bash` (avec vos variables d'environnement dans ../.env.secretariat.dev )
-
-
-## Production
-
-`npm run start`


### PR DESCRIPTION
## Serveurs Mock

Ce PR documente les options pour reemplacer l'URL pour le webhook Slack en développement avec des outils tels que [Beeceptor](https://beeceptor.com/), [Mockoon](https://mockoon.com/) ou [Postman](https://www.postman.com/).

## Mise en format

Certains élèments du `README.md` sont mis en format, par exemple:
- les variables d'environnement ont un format `code`
- à coté des variables d'environnement il y a un lien vers la section qui explique comment le configurer pour le développement
- cohérence des titres entre les sections

Pour voir le résultat c'est par ici : https://github.com/betagouv/secretariat/tree/task/add-documentation