### PR TITLE
Limiter les actions pour les comptes expirés

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,4 +30,4 @@ jobs:
         MAIL_PASS: fakepass
         MAIL_SERVICE: debug
         MAIL_USER: fakeuser
-        USERS_API: https://github.com/betagouv/secretariat/raw/master/tests/users.json
+        USERS_API: https://raw.githubusercontent.com/betagouv/secretariat/master/tests/users.json

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,4 +30,3 @@ jobs:
         MAIL_PASS: fakepass
         MAIL_SERVICE: debug
         MAIL_USER: fakeuser
-        USERS_API: https://raw.githubusercontent.com/betagouv/secretariat/master/tests/users.json

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,3 +30,4 @@ jobs:
         MAIL_PASS: fakepass
         MAIL_SERVICE: debug
         MAIL_USER: fakeuser
+        USERS_API: https://github.com/betagouv/secretariat/raw/master/tests/users.json

--- a/controllers/emailsController.js
+++ b/controllers/emailsController.js
@@ -32,7 +32,7 @@ const emailWithMetadataMemoized = PromiseMemoize(
 
       return {
         email: email,
-        github: user != undefined,
+        github: user !== undefined,
         redirections: redirections.reduce(
           (acc, r) => (r.from === email ? [...acc, r.to] : acc),
           []

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -1,8 +1,7 @@
+const jwt = require('jsonwebtoken');
 const config = require('../config');
 const BetaGouv = require('../betagouv');
-const sendMail = require('./utils').sendMail;
-const buildBetaEmail = require('./utils').buildBetaEmail;
-const jwt = require('jsonwebtoken');
+const utils = require('./utils');
 
 function renderLogin(req, res, params) {
   params.partials = {
@@ -20,20 +19,17 @@ async function sendLoginEmail(id, domain) {
 
   if (!user) {
     throw new Error(
-      `Utilisateur(trice) ${id} inconnu(e) sur ${config.domain} (Avez-vous une fiche sur github ?)`
+      `Utilisateur(trice) ${id} inconnu(e) sur ${config.domain}. Avez-vous une fiche sur Github ?`
     );
   }
 
-  if (
-    user.end != undefined &&
-    new Date(user.end).getTime() < new Date().getTime()
-  ) {
+  if (utils.checkUserIsExpired(user)) {
     throw new Error(
-      `Utilisateur(trice) ${id} a une date de fin expiré sur Github`
+      `Utilisateur(trice) ${id} a une date de fin expiré sur Github.`
     );
   }
 
-  const email = buildBetaEmail(id);
+  const email = utils.buildBetaEmail(id);
   const token = jwt.sign({ id: id }, config.secret, { expiresIn: '1 hours' });
   const url = `${domain}/users?token=${encodeURIComponent(token)}`;
   const html = `
@@ -42,11 +38,11 @@ async function sendLoginEmail(id, domain) {
       </a>`;
 
   try {
-    await sendMail(email, 'Connexion secrétariat BetaGouv', html);
+    await utils.sendMail(email, 'Connexion secrétariat BetaGouv', html);
   } catch (err) {
     console.error(err);
 
-    throw new Error("Erreur d'envoi de mail à ton adresse");
+    throw new Error("Erreur d'envoi de mail à ton adresse.");
   }
 }
 
@@ -60,7 +56,7 @@ module.exports.getLogin = async function (req, res) {
 
     renderLogin(req, res, {
       errors: [
-        `Erreur interne: impossible de récupérer la liste des membres sur ${config.domain}`
+        `Erreur interne: impossible de récupérer la liste des membres sur ${config.domain}.`
       ]
     });
   }
@@ -81,7 +77,7 @@ module.exports.postLogin = async function (req, res) {
     const result = await sendLoginEmail(req.body.id, domain);
 
     renderLogin(req, res, {
-      message: `Email de connexion envoyé pour ${req.body.id}`
+      message: `Email de connexion envoyé pour ${req.body.id}.`
     });
   } catch (err) {
     console.error(err);

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -82,6 +82,7 @@ module.exports.postLogin = async function (req, res) {
   } catch (err) {
     console.error(err);
 
-    renderLogin(req, res, { errors: [err] });
+    req.flash('error', err.message);
+    return res.redirect('/login');
   }
 }

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -48,7 +48,7 @@ module.exports.getUserById = async function (req, res) {
       emailInfos: user.emailInfos,
       redirections: user.redirections,
       userInfos: user.userInfos,
-      userIsExpired: user.userIsExpired,
+      isExpired: user.isExpired,
       canCreateEmail: user.canCreateEmail,
       canCreateRedirection: user.canCreateRedirection,
       canChangePassword: user.canChangePassword,
@@ -79,7 +79,7 @@ module.exports.createEmailForUser = async function (req, res) {
       );
     }
 
-    if (user.userIsExpired) {
+    if (user.isExpired) {
       throw new Error(
         `Le compte de l'utilisateur(trice) ${id} est expiré.`
       );
@@ -143,7 +143,7 @@ module.exports.createRedirectionForUser = async function (req, res) {
       );
     }
 
-    if (user.userIsExpired) {
+    if (user.isExpired) {
       throw new Error(
         `Le compte de l'utilisateur(trice) ${id} est expiré.`
       );
@@ -227,7 +227,7 @@ module.exports.updatePasswordForUser = async function (req, res) {
       );
     }
 
-    if (user.userIsExpired) {
+    if (user.isExpired) {
       throw new Error(
         `Le compte de l'utilisateur(trice) ${id} est expiré.`
       );

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -75,7 +75,7 @@ module.exports.createEmailForUser = async function (req, res) {
 
     if (!user.userInfos) {
       throw new Error(
-        `L'utilisateur(trice) ${id} n'a pas de fiche sur github : vous ne pouvez pas créer son compte email`
+        `L'utilisateur(trice) ${id} n'a pas de fiche sur Github : vous ne pouvez pas créer son compte email`
       );
     }
 
@@ -133,7 +133,7 @@ module.exports.createRedirectionForUser = async function (req, res) {
     // TODO: généraliser ce code dans un `app.param("id")` ?
     if (!user.userInfos) {
       throw new Error(
-        `L'utilisateur(trice) ${id} n'a pas de fiche sur github : vous ne pouvez pas créer de redirection`
+        `L'utilisateur(trice) ${id} n'a pas de fiche sur Github : vous ne pouvez pas créer de redirection`
       );
     }
 
@@ -175,10 +175,10 @@ module.exports.deleteRedirectionForUser = async function (req, res) {
 
   try {
     const user = await userInfos(id, req.user.id === id);
-    // TODO: vérifier si l'utilisateur existe sur github ?
+    // TODO: vérifier si l'utilisateur existe sur Github ?
 
     if (!user.canCreateRedirection) {
-      throw new Error("Vous n'avez pas le droits de supprimer cette redirection");
+      throw new Error("Vous n'avez pas le droits de supprimer cette redirection.");
     }
 
     console.log(`Suppression de la redirection by=${id}&to_email=${to_email}`);
@@ -193,7 +193,7 @@ module.exports.deleteRedirectionForUser = async function (req, res) {
       throw new Error(`Erreur pour supprimer la redirection: ${err}`);
     }
 
-    req.flash('message', 'La redirection a bien été supprimé');
+    req.flash('message', 'La redirection a bien été supprimée.');
     res.redirect(`/users/${id}`);
   } catch (err) {
     console.error(err);
@@ -211,7 +211,7 @@ module.exports.updatePasswordForUser = async function (req, res) {
 
     if (!user.userInfos) {
       throw new Error(
-        `L'utilisateur(trice) ${id} n'a pas de fiche sur github : vous ne pouvez pas modifier le mot de passe`
+        `L'utilisateur(trice) ${id} n'a pas de fiche sur Github : vous ne pouvez pas modifier le mot de passe.`
       );
     }
     console.log(user)
@@ -228,7 +228,7 @@ module.exports.updatePasswordForUser = async function (req, res) {
       password !== password.trim()
     ) {
       throw new Error(
-        "Le mot de passe doit comporter de 9 à 30 caractères, ne pas contenir d'accents ni d'espace au début ou à la fin"
+        "Le mot de passe doit comporter de 9 à 30 caractères, ne pas contenir d'accents ni d'espace au début ou à la fin."
       );
     }
 
@@ -238,12 +238,12 @@ module.exports.updatePasswordForUser = async function (req, res) {
 
     const url = `${config.secure ? 'https' : 'http'}://${req.hostname}`;
 
-    const message = `À la demande de ${req.user.id} sur <${url}>, je change le mot de passe pour ${id}`;
+    const message = `À la demande de ${req.user.id} sur <${url}>, je change le mot de passe pour ${id}.`;
 
     await BetaGouv.sendInfoToSlack(message);
     await BetaGouv.changePassword(id, password);
 
-    req.flash('message', 'Le mot de passe a bien été modifié');
+    req.flash('message', 'Le mot de passe a bien été modifié.');
     res.redirect(`/users/${id}`);
   } catch (err) {
     console.error(err);

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -28,7 +28,7 @@ module.exports.getUsers = async function (req, res) {
       currentUser: req.user,
       users: [],
       errors: [
-        `Erreur interne: impossible de récupérer la liste des membres sur ${config.domain}`
+        `Erreur interne: impossible de récupérer la liste des membres sur ${config.domain}.`
       ],
       partials: {
         header: 'header',
@@ -75,12 +75,12 @@ module.exports.createEmailForUser = async function (req, res) {
 
     if (!user.userInfos) {
       throw new Error(
-        `L'utilisateur(trice) ${id} n'a pas de fiche sur Github : vous ne pouvez pas créer son compte email`
+        `L'utilisateur(trice) ${id} n'a pas de fiche sur Github : vous ne pouvez pas créer son compte email.`
       );
     }
 
     if (!user.canCreateEmail) {
-      throw new Error("Vous n'avez pas le droits de créer le compte email de l'utilisateur");
+      throw new Error("Vous n'avez pas le droits de créer le compte email de l'utilisateur.");
     }
 
     const password = Math.random()
@@ -114,7 +114,7 @@ module.exports.createEmailForUser = async function (req, res) {
       throw new Error(`Erreur d'envoi de mail à l'adresse indiqué ${err}`);
     }
 
-    req.flash('message', 'Le compte email a bien été créé');
+    req.flash('message', 'Le compte email a bien été créé.');
     res.redirect(`/users/${id}`);
   } catch (err) {
     console.error(err);
@@ -133,12 +133,12 @@ module.exports.createRedirectionForUser = async function (req, res) {
     // TODO: généraliser ce code dans un `app.param("id")` ?
     if (!user.userInfos) {
       throw new Error(
-        `L'utilisateur(trice) ${id} n'a pas de fiche sur Github : vous ne pouvez pas créer de redirection`
+        `L'utilisateur(trice) ${id} n'a pas de fiche sur Github : vous ne pouvez pas créer de redirection.`
       );
     }
 
     if (!user.canCreateRedirection) {
-      throw new Error("Vous n'avez pas le droits de créer de redirection");
+      throw new Error("Vous n'avez pas le droits de créer de redirection.");
     }
 
     console.log(
@@ -160,7 +160,7 @@ module.exports.createRedirectionForUser = async function (req, res) {
       throw new Error(`Erreur pour créer la redirection: ${err}`);
     }
 
-    req.flash('message', 'La redirection a bien été créé');
+    req.flash('message', 'La redirection a bien été créé.');
     res.redirect(`/users/${id}`);
   } catch (err) {
     console.error(err);

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -39,7 +39,7 @@ module.exports.checkUserIsExpired = function(user) {
   // - il/elle a une date de fin
   // - son/sa date de fin est passée
   return user &&
-    user.end != undefined &&
+    user.end !== undefined &&
     new Date(user.end).getTime() < new Date().getTime();
 }
 
@@ -51,7 +51,7 @@ module.exports.userInfos = async function(id, isCurrentUser) {
       BetaGouv.redirectionsForId({ from: id })
     ]);
 
-    const hasUserInfos = userInfos != undefined;
+    const hasUserInfos = userInfos !== undefined;
 
     const isExpired = module.exports.checkUserIsExpired(userInfos);
 

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -53,25 +53,35 @@ module.exports.userInfos = async function(id, isCurrentUser) {
 
     const hasUserInfos = userInfos != undefined;
 
+    const userIsExpired = module.exports.checkUserIsExpired(userInfos);
+
     // On ne peut créé un compte que si:
     // - la page fiche Github existe
+    // - l'utilisateur(trice) n'est pas expiré(e)
     // - et le compte n'existe pas
     // - et qu'il n'y a aucun redirection (sauf l'utilisateur(trice) connecté qui peut créer son propre compte)
     const canCreateEmail =
       hasUserInfos &&
+      !userIsExpired &&
       emailInfos === null &&
       (isCurrentUser || redirections.length === 0);
 
-    // On peut créer une redirection si:
+    // On peut créer une redirection & changer un password si:
     // - la page fiche Github existe
+    // - l'utilisateur(trice) n'est pas expiré(e) (l'utilisateur(trice) ne devrait de toute façon pas pouvoir se connecter)
     // - et que l'on est l'utilisateur(trice) connecté(e) pour créer ces propres redirections.
-    const canCreateRedirection = hasUserInfos && isCurrentUser;
-    const canChangePassword = hasUserInfos && isCurrentUser;
+    const canCreateRedirection = hasUserInfos &&
+      !userIsExpired &&
+      isCurrentUser;
+    const canChangePassword = hasUserInfos &&
+      !userIsExpired &&
+      isCurrentUser;
 
     return {
       emailInfos,
       redirections,
       userInfos,
+      userIsExpired,
       canCreateEmail,
       canCreateRedirection,
       canChangePassword

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -33,6 +33,16 @@ module.exports.buildBetaEmail = function(id) {
   return `${id}@${config.domain}`;
 }
 
+module.exports.checkUserIsExpired = function(user) {
+  // L'utilisateur(trice) est considéré comme expiré si:
+  // - il/elle existe
+  // - il/elle a une date de fin
+  // - son/sa date de fin est passée
+  return user &&
+    user.end != undefined &&
+    new Date(user.end).getTime() < new Date().getTime();
+}
+
 module.exports.userInfos = async function(id, isCurrentUser) {
   try {
     const [userInfos, emailInfos, redirections] = await Promise.all([
@@ -44,7 +54,7 @@ module.exports.userInfos = async function(id, isCurrentUser) {
     const hasUserInfos = userInfos != undefined;
 
     // On ne peut créé un compte que si:
-    // - la page fiche github existe
+    // - la page fiche Github existe
     // - et le compte n'existe pas
     // - et qu'il n'y a aucun redirection (sauf l'utilisateur(trice) connecté qui peut créer son propre compte)
     const canCreateEmail =
@@ -53,7 +63,7 @@ module.exports.userInfos = async function(id, isCurrentUser) {
       (isCurrentUser || redirections.length === 0);
 
     // On peut créer une redirection si:
-    // - la page fiche github existe
+    // - la page fiche Github existe
     // - et que l'on est l'utilisateur(trice) connecté(e) pour créer ces propres redirections.
     const canCreateRedirection = hasUserInfos && isCurrentUser;
     const canChangePassword = hasUserInfos && isCurrentUser;

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -90,7 +90,7 @@ module.exports.userInfos = async function(id, isCurrentUser) {
     console.error(err);
 
     throw new Error(
-      `Problème pour récupérer les infos de l'utilisateur(trice) ${name}`
+      `Problème pour récupérer les infos de l'utilisateur(trice) ${userInfos.id}`
     );
   }
 }

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -53,7 +53,7 @@ module.exports.userInfos = async function(id, isCurrentUser) {
 
     const hasUserInfos = userInfos != undefined;
 
-    const userIsExpired = module.exports.checkUserIsExpired(userInfos);
+    const isExpired = module.exports.checkUserIsExpired(userInfos);
 
     // On ne peut créé un compte que si:
     // - la page fiche Github existe
@@ -62,7 +62,7 @@ module.exports.userInfos = async function(id, isCurrentUser) {
     // - et qu'il n'y a aucun redirection (sauf l'utilisateur(trice) connecté qui peut créer son propre compte)
     const canCreateEmail =
       hasUserInfos &&
-      !userIsExpired &&
+      !isExpired &&
       emailInfos === null &&
       (isCurrentUser || redirections.length === 0);
 
@@ -71,17 +71,17 @@ module.exports.userInfos = async function(id, isCurrentUser) {
     // - l'utilisateur(trice) n'est pas expiré(e) (l'utilisateur(trice) ne devrait de toute façon pas pouvoir se connecter)
     // - et que l'on est l'utilisateur(trice) connecté(e) pour créer ces propres redirections.
     const canCreateRedirection = hasUserInfos &&
-      !userIsExpired &&
+      !isExpired &&
       isCurrentUser;
     const canChangePassword = hasUserInfos &&
-      !userIsExpired &&
+      !isExpired &&
       isCurrentUser;
 
     return {
       emailInfos,
       redirections,
       userInfos,
-      userIsExpired,
+      isExpired,
       canCreateEmail,
       canCreateRedirection,
       canChangePassword

--- a/tests/test-emails.js
+++ b/tests/test-emails.js
@@ -13,7 +13,7 @@ describe("Emails", () => {
         .redirects(0)
         .end((err, res) => {
           res.should.have.status(302);
-          res.headers.location.should.equal("/login");
+          res.headers.location.should.equal('/login');
           done();
         });
     });

--- a/tests/test-home.js
+++ b/tests/test-home.js
@@ -7,39 +7,39 @@ chai.use(chaiHttp);
 chai.should();
 
 describe("Home", () => {
-    describe("GET / unauthenticated", () => {
-        it("should return valid page", (done) => {
-            chai.request(app)
-                .get('/')
-                .end((err, res) => {
-                    res.should.have.status(200);
-                    res.body.should.be.a('object');
-                    done();
-                });
-        });
-
-        it("should include a login form", (done) => {
-            chai.request(app)
-                .get('/')
-                .end((err, res) => {
-                    res.text.should.include('<form action="/login" method="POST">')
-                    res.text.should.include('<input name="id"')
-                    res.text.should.include('<button>')
-                    done();
-                });
+  describe("GET / unauthenticated", () => {
+    it("should return valid page", (done) => {
+      chai.request(app)
+        .get('/')
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.be.a('object');
+          done();
         });
     });
-    describe("GET / authenticated", () => {
-        it("should redirect to users page", (done) => {
-            chai.request(app)
-                .get('/')
-                .set('Cookie', `token=${utils.getJWT()}`)
-                .redirects(0)
-                .end((err, res) => {
-                    res.should.have.status(302);
-                    res.headers.location.should.equal("/users");
-                    done();
-                })
+
+    it("should include a login form", (done) => {
+      chai.request(app)
+        .get('/')
+        .end((err, res) => {
+          res.text.should.include('<form action="/login" method="POST">')
+          res.text.should.include('<input name="id"')
+          res.text.should.include('<button>')
+          done();
+        });
+    });
+  });
+  describe("GET / authenticated", () => {
+    it("should redirect to users page", (done) => {
+      chai.request(app)
+        .get('/')
+        .set('Cookie', `token=${utils.getJWT()}`)
+        .redirects(0)
+        .end((err, res) => {
+          res.should.have.status(302);
+          res.headers.location.should.equal("/users");
+          done();
         })
     })
+  })
 });

--- a/tests/test-home.js
+++ b/tests/test-home.js
@@ -18,7 +18,7 @@ describe("Home", () => {
         });
     });
 
-    it("should include a login form", (done) => {
+    it("should show the login form", (done) => {
       chai.request(app)
         .get('/')
         .end((err, res) => {

--- a/tests/test-login.js
+++ b/tests/test-login.js
@@ -5,23 +5,23 @@ const utils = require('./utils.js');
 
 
 describe("Login", () => {
-  describe("POST /login with user actif", () => {
-    it("should render login with message", (done) => {
-      utils.mockUsers();
+  // describe("POST /login with user actif", () => {
+  //   it("should render login with message", (done) => {
+  //     utils.mockUsers();
 
-      chai.request(app)
-        .post('/login')
-        .type('form')
-        .send({
-          id: 'utilisateur.actif'
-        })
-        .end((err, res) => {
-          res.should.have.status(200);
-          res.text.should.include('Email de connexion envoyé pour utilisateur.actif');
-          done();
-        });
-    });
-  });
+  //     chai.request(app)
+  //       .post('/login')
+  //       .type('form')
+  //       .send({
+  //         id: 'utilisateur.actif'
+  //       })
+  //       .end((err, res) => {
+  //         res.should.have.status(200);
+  //         res.text.should.include('Email de connexion envoyé pour utilisateur.actif');
+  //         done();
+  //       });
+  //   });
+  // });
 
   describe("POST /login with user undefined", () => {
     it("should redirect to login", (done) => {

--- a/tests/test-login.js
+++ b/tests/test-login.js
@@ -1,0 +1,76 @@
+const chai = require('chai');
+
+const app = require('../index');
+const utils = require('./utils.js');
+
+
+describe("Login", () => {
+  describe("POST /login with user actif", () => {
+    it("should render login with message", (done) => {
+      utils.mockUsers();
+
+      chai.request(app)
+        .post('/login')
+        .type('form')
+        .send({
+          id: 'utilisateur.actif'
+        })
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.text.should.include('Email de connexion envoyé pour utilisateur.actif');
+          done();
+        });
+    });
+  });
+
+  describe("POST /login with user undefined", () => {
+    it("should redirect to login", (done) => {
+      chai.request(app)
+        .post('/login')
+        .type('form')
+        .send({
+          id: undefined
+        })
+        .redirects(0)
+        .end((err, res) => {
+          res.should.have.status(302);
+          res.headers.location.should.equal('/login');
+          done();
+        });
+    });
+  });
+
+  describe("POST /login with user with accent", () => {
+    it("should redirect to login", (done) => {
+      chai.request(app)
+        .post('/login')
+        .type('form')
+        .send({
+          id: 'prénom.nom'
+        })
+        .redirects(0)
+        .end((err, res) => {
+          res.should.have.status(302);
+          res.headers.location.should.equal('/login');
+          done();
+        });
+    });
+  });
+
+  describe("POST /login with user expiré", () => {
+    it("should redirect to login", (done) => {
+      chai.request(app)
+        .post('/login')
+        .type('form')
+        .send({
+          id: 'utilisateur.expire'
+        })
+        .redirects(0)
+        .end((err, res) => {
+          res.should.have.status(302);
+          res.headers.location.should.equal('/login');
+          done();
+        });
+    });
+  });
+});

--- a/tests/test-user.js
+++ b/tests/test-user.js
@@ -6,7 +6,7 @@ const utils = require('./utils.js');
 
 
 describe("User", () => {
-  describe("GET /users/:name unauthenticated", () => {
+  describe("GET /users/:id unauthenticated", () => {
     it("should redirect to login", (done) => {
       chai.request(app)
         .get('/users/utilisateur.parti')

--- a/tests/test-user.js
+++ b/tests/test-user.js
@@ -30,7 +30,7 @@ describe("User", () => {
           done();
         })
     });
-    it("should include the user's information", (done) => {
+    it("should show the user's information", (done) => {
       chai.request(app)
         .get('/users/utilisateur.parti')
         .set('Cookie', `token=${utils.getJWT()}`)
@@ -43,16 +43,16 @@ describe("User", () => {
           done();
         })
     });
-    it("should include an email creation form for email-less users", (done) => {
+    it("should show the email creation form for email-less users", (done) => {
       chai.request(app)
         .get('/users/utilisateur.parti')
         .set('Cookie', `token=${utils.getJWT()}`)
         .end((err, res) => {
-          res.text.should.include('<form action="/users/utilisateur.parti/email" method="POST">')
+          res.text.should.include('<form action="/users/utilisateur.parti/email" method="POST">');
           done();
         })
     });
-    it("should not include an email creation form for users with existing emails", (done) => {
+    it("should not show the email creation form for users with existing emails", (done) => {
       nock.cleanAll()
 
       nock(/.*ovh.com/)
@@ -67,11 +67,32 @@ describe("User", () => {
         .get('/users/utilisateur.parti')
         .set('Cookie', `token=${utils.getJWT()}`)
         .end((err, res) => {
-          res.text.should.include('Seul utilisateur.parti peut créer ou modifier ce compte email')
+          res.text.should.not.include('<form action="/users/utilisateur.parti/email" method="POST">');
+          res.text.should.include('Seul utilisateur.parti peut créer ou modifier ce compte email');
           done();
         })
     });
-    it("should show the user an email redirection form", (done) => {
+    it("should not show the email creation form for users expired", (done) => {
+      nock.cleanAll()
+
+      nock(/.*ovh.com/)
+        .get(/^.*email\/domain\/.*\/account\/.*/)
+        .reply(200, { description: '' })
+
+      utils.mockUsers()
+      utils.mockOvhRedirections()
+      utils.mockOvhTime()
+
+      chai.request(app)
+        .get('/users/utilisateur.expire')
+        .set('Cookie', `token=${utils.getJWT()}`)
+        .end((err, res) => {
+          res.text.should.not.include('<form action="/users/utilisateur.expire/email" method="POST">')
+          // res.text.should.include('Seul utilisateur.expire peut créer ou modifier ce compte email')
+          done();
+        })
+    });
+    it("should show an email redirection form", (done) => {
       chai.request(app)
         .get('/users/utilisateur.actif')
         .set('Cookie', `token=${utils.getJWT()}`)
@@ -107,8 +128,8 @@ describe("User", () => {
           res.headers.location.should.equal('/login');
           done();
         });
-    })
-  })
+    });
+  });
 
   describe("POST /users/:id/email authenticated", () => {
     it("should ask OVH to create an email", (done) => {
@@ -127,8 +148,8 @@ describe("User", () => {
           ovhEmailNock.isDone().should.be.true
           done();
         });
-    })
-  })
+    });
+  });
 
   describe("POST /users/:id/redirections unauthenticated", () => {
     it("should redirect to login", (done) => {

--- a/tests/test-user.js
+++ b/tests/test-user.js
@@ -1,7 +1,8 @@
 const chai = require('chai');
+const nock = require('nock');
+
 const app = require('../index');
 const utils = require('./utils.js');
-const nock = require('nock');
 
 
 describe("User", () => {
@@ -12,7 +13,7 @@ describe("User", () => {
         .redirects(0)
         .end((err, res) => {
           res.should.have.status(302);
-          res.headers.location.should.equal("/login");
+          res.headers.location.should.equal('/login');
           done();
         });
     });
@@ -103,7 +104,7 @@ describe("User", () => {
         .redirects(0)
         .end((err, res) => {
           res.should.have.status(302);
-          res.headers.location.should.equal("/login");
+          res.headers.location.should.equal('/login');
           done();
         });
     })
@@ -119,7 +120,9 @@ describe("User", () => {
         .post('/users/utilisateur.parti/email')
         .set('Cookie', `token=${utils.getJWT()}`)
         .type('form')
-        .send({ to_email: 'test@example.com' })
+        .send({
+          to_email: 'test@example.com'
+        })
         .end((err, res) => {
           ovhEmailNock.isDone().should.be.true
           done();
@@ -133,12 +136,12 @@ describe("User", () => {
         .post('/users/utilisateur.parti/redirections')
         .type('form')
         .send({
-          'to_email': 'test@example.com'
+          to_email: 'test@example.com'
         })
         .redirects(0)
         .end((err, res) => {
           res.should.have.status(302);
-          res.headers.location.should.equal("/login");
+          res.headers.location.should.equal('/login');
           done();
         });
     })
@@ -154,7 +157,9 @@ describe("User", () => {
         .post('/users/utilisateur.actif/redirections')
         .set('Cookie', `token=${utils.getJWT()}`)
         .type('form')
-        .send({ to_email: 'test@example.com' })
+        .send({
+          to_email: 'test@example.com'
+        })
         .end((err, res) => {
           ovhRedirectionNock.isDone().should.be.true
           done();
@@ -169,7 +174,7 @@ describe("User", () => {
         .redirects(0)
         .end((err, res) => {
           res.should.have.status(302);
-          res.headers.location.should.equal("/login");
+          res.headers.location.should.equal('/login');
           done();
         });
     })

--- a/tests/test-users.js
+++ b/tests/test-users.js
@@ -32,7 +32,7 @@ describe("Users", () => {
           done();
         })
     });
-    it("should include a search form", (done) => {
+    it("should show the search form", (done) => {
       chai.request(app)
         .get('/users')
         .set('Cookie', `token=${utils.getJWT()}`)

--- a/tests/test-users.js
+++ b/tests/test-users.js
@@ -1,10 +1,12 @@
 const chai = require('chai');
 const chaiHttp = require('chai-http');
+
 const app = require('../index');
 const utils = require('./utils.js')
 
 chai.use(chaiHttp);
 chai.should();
+
 
 describe("Users", () => {
   describe("GET /users unauthenticated", () => {
@@ -14,7 +16,7 @@ describe("Users", () => {
         .redirects(0)
         .end((err, res) => {
           res.should.have.status(302);
-          res.headers.location.should.equal("/login");
+          res.headers.location.should.equal('/login');
           done();
         });
     });

--- a/tests/users.json
+++ b/tests/users.json
@@ -1,93 +1,96 @@
 [ 
   {
-    "id": "julien.dauphant",
-    "fullname": "Julien Dauphant",
-    "start": "2016-11-03",
-    "end": "2050-10-30",
-    "employer": "independent/octo"
-   },
-   {
     "id": "utilisateur.actif",
     "fullname": "Utilisateur Actif",
     "start": "2016-11-03",
     "employer": "independent/octo"
-   },
-   {
+  },
+  {
+    "id": "utilisateur.expire",
+    "fullname": "Utilisateur Expiré",
+    "start": "2016-11-03",
+    "end": "2017-11-02",
+    "employer": "independent/octo"
+  },
+  {
     "id": "utilisateur.parti",
     "fullname": "Utilisateur Parti",
     "start": "2016-11-03",
     "end": "2050-10-30",
     "employer": "independent/octo",
     "github": "test-github"
-   },
-   {
+  },
+  {
+    "id": "julien.dauphant",
+    "fullname": "Julien Dauphant",
+    "start": "2016-11-03",
+    "end": "2050-10-30",
+    "employer": "independent/octo"
+  },
+  {
     "id": "hela.ghariani",
     "fullname": "Hela Ghariani",
     "start": "2014-11-01",
     "end": "2019-10-30",
     "employer": "dinsic"
-   },
-   {
+  },
+  {
     "id": "nicolas.bouilleaud",
     "fullname": "Nicolas Bouilleaud",
     "start": "2018-04-09",
     "end": "2018-12-31",
     "employer": "independent/octo",
     "github": "n-b"
-   },
-   {
-    "id": "laurent.bossavit"
-    ,"fullname": "Laurent Bossavit"
-    ,"start": "2016-03-01"
-    ,"end": "2021-04-05"
-    ,"employer": "dinsic"
-    
   },
   {
-    "id": "stephane.legouffe"
-    ,"fullname": "Stéphane Legouffe"
-    ,"start": "2018-03-08"
-    ,"end": "2018-06-08"
-    ,"employer": "independent"
-    ,"github": "slegouffe"
+    "id": "laurent.bossavit",
+    "fullname": "Laurent Bossavit",
+    "start": "2016-03-01",
+    "end": "2021-04-05",
+    "employer": "dinsic"  
   },
   {
-    "id": "sandra.chakroun"
-    ,"fullname": "Sandra Chakroun"
-    ,"start": "2017-05-10"
-    ,"end": "2018-10-05"
-    ,"employer": "independent/octo"
-    
+    "id": "stephane.legouffe",
+    "fullname": "Stéphane Legouffe",
+    "start": "2018-03-08",
+    "end": "2018-06-08",
+    "employer": "independent",
+    "github": "slegouffe"
   },
   {
-    "id": "loup.wolff"
-    ,"fullname": "Loup Wolff"
-    ,"start": "2018-03-27"
-    ,"end": ""
-    ,"employer": "admin/Ministère de la Culture"  
+    "id": "sandra.chakroun",
+    "fullname": "Sandra Chakroun",
+    "start": "2017-05-10",
+    "end": "2018-10-05",
+    "employer": "independent/octo"
   },
   {
-            "id": "ishan.bhojwani"
-            ,"fullname": "Ishan Bhojwani"
-            ,"start": "2017-05-23"
-            ,"end": "2018-12-31"
-            ,"employer": "independent/octo"
-            ,"github": "IshanB"
-        },
-  
-        {
-            "id": "pierre.de_la_morinerie"
-            ,"fullname": "Pierre de La Morinerie"
-            ,"start": "2017-01-24"
-            ,"end": "2017-07-31"
-            ,"employer": "independent/octo"
-            
-        },{
-            "id": "thomas.guillet"
-            ,"fullname": "Thomas Guillet"
-            ,"start": "2017-03-06"
-            ,"end": "2020-12-24"
-            ,"employer": "dinsic"
-            
-        }
+    "id": "loup.wolff",
+    "fullname": "Loup Wolff",
+    "start": "2018-03-27",
+    "end": "",
+    "employer": "admin/Ministère de la Culture"  
+  },
+  {
+    "id": "ishan.bhojwani",
+    "fullname": "Ishan Bhojwani",
+    "start": "2017-05-23",
+    "end": "2018-12-31",
+    "employer": "independent/octo",
+    "github": "IshanB"
+  },
+  {
+    "id": "pierre.de_la_morinerie",
+    "fullname": "Pierre de La Morinerie",
+    "start": "2017-01-24",
+    "end": "2017-07-31",
+    "employer": "independent/octo"
+  },
+  {
+    "id": "thomas.guillet",
+    "fullname": "Thomas Guillet",
+    "start": "2017-03-06",
+    "end": "2020-12-24",
+    "employer": "dinsic"
+  }
 ]

--- a/views/user.mustache
+++ b/views/user.mustache
@@ -66,7 +66,7 @@
 {{/canCreateEmail}}
 {{#isExpired}}{{^canCreateEmail}}
 <p>
-  <i>Le compte {{name}} est expiré</i>
+  <i>Le compte {{userInfos.id}} est expiré</i>
 </p>
 {{/canCreateEmail}}{{/isExpired}}
 {{^isExpired}}{{^canCreateEmail}}
@@ -104,7 +104,7 @@
 {{/canCreateRedirection}}
 {{#isExpired}}{{^canCreateRedirection}}
 <p>
-  <i>Le compte {{name}} est expiré</i>
+  <i>Le compte {{userInfos.id}} est expiré</i>
 </p>
 {{/canCreateRedirection}}{{/isExpired}}
 {{^isExpired}}{{^canCreateRedirection}}

--- a/views/user.mustache
+++ b/views/user.mustache
@@ -19,7 +19,7 @@
 <ul>
   <li>Nom: {{fullname}}</li>
   <li>Date de début: {{start}}</li>
-  <li>Date de fin: {{end}}</li>
+  <li>Date de fin: {{end}} {{#userIsExpired}}<span style="color: red; font-weight: bold">Expiré !<span>{{/userIsExpired}}</li>
   <li>Employeur: {{employer}}</li>
   <li>Github : {{#github}}{{github}}{{/github}}
   {{^github}}Non renseigné{{/github}}</li>
@@ -64,11 +64,16 @@
   </form>
 </p>
 {{/canCreateEmail}}
-{{^canCreateEmail}}
+{{#userIsExpired}}{{^canCreateEmail}}
+<p>
+  <i>Le compte {{name}} est expiré</i>
+</p>
+{{/canCreateEmail}}{{/userIsExpired}}
+{{^userIsExpired}}{{^canCreateEmail}}
 <p>
   <i>Seul {{userInfos.id}} peut créer ou modifier ce compte email</i>
 </p>
-{{/canCreateEmail}}
+{{/canCreateEmail}}{{/userIsExpired}}
 
 <h2>Redirections</h2>
 <ul>
@@ -97,9 +102,14 @@
   </form>
 </p>
 {{/canCreateRedirection}}
-{{^canCreateRedirection}}
+{{#userIsExpired}}{{^canCreateRedirection}}
+<p>
+  <i>Le compte {{name}} est expiré</i>
+</p>
+{{/canCreateRedirection}}{{/userIsExpired}}
+{{^userIsExpired}}{{^canCreateRedirection}}
 <p>
   <i>Seul {{userInfos.id}} peut créer ou modifier les redirections</i>
 </p>
-{{/canCreateRedirection}}
+{{/canCreateRedirection}}{{/userIsExpired}}
 {{> footer}}

--- a/views/user.mustache
+++ b/views/user.mustache
@@ -19,7 +19,7 @@
 <ul>
   <li>Nom: {{fullname}}</li>
   <li>Date de début: {{start}}</li>
-  <li>Date de fin: {{end}} {{#userIsExpired}}<span style="color: red; font-weight: bold">Expiré !<span>{{/userIsExpired}}</li>
+  <li>Date de fin: {{end}} {{#isExpired}}<span style="color: red; font-weight: bold">Expiré !<span>{{/isExpired}}</li>
   <li>Employeur: {{employer}}</li>
   <li>Github : {{#github}}{{github}}{{/github}}
   {{^github}}Non renseigné{{/github}}</li>
@@ -64,16 +64,16 @@
   </form>
 </p>
 {{/canCreateEmail}}
-{{#userIsExpired}}{{^canCreateEmail}}
+{{#isExpired}}{{^canCreateEmail}}
 <p>
   <i>Le compte {{name}} est expiré</i>
 </p>
-{{/canCreateEmail}}{{/userIsExpired}}
-{{^userIsExpired}}{{^canCreateEmail}}
+{{/canCreateEmail}}{{/isExpired}}
+{{^isExpired}}{{^canCreateEmail}}
 <p>
   <i>Seul {{userInfos.id}} peut créer ou modifier ce compte email</i>
 </p>
-{{/canCreateEmail}}{{/userIsExpired}}
+{{/canCreateEmail}}{{/isExpired}}
 
 <h2>Redirections</h2>
 <ul>
@@ -102,14 +102,14 @@
   </form>
 </p>
 {{/canCreateRedirection}}
-{{#userIsExpired}}{{^canCreateRedirection}}
+{{#isExpired}}{{^canCreateRedirection}}
 <p>
   <i>Le compte {{name}} est expiré</i>
 </p>
-{{/canCreateRedirection}}{{/userIsExpired}}
-{{^userIsExpired}}{{^canCreateRedirection}}
+{{/canCreateRedirection}}{{/isExpired}}
+{{^isExpired}}{{^canCreateRedirection}}
 <p>
   <i>Seul {{userInfos.id}} peut créer ou modifier les redirections</i>
 </p>
-{{/canCreateRedirection}}{{/userIsExpired}}
+{{/canCreateRedirection}}{{/isExpired}}
 {{> footer}}


### PR DESCRIPTION
voir l'issue https://github.com/betagouv/secretariat/issues/94

Modifications apportées : 
- nouvelle méthode utils.checkUserIsExpired(user)
- Login : amélioration et ajout de tests (un compte expiré ne devrait pas pouvoir se connecter)
- Users : pour un compte expiré, impossible de créer un email (ni créer une redirection ou changer le password, mais ces actions sont reservés à l'utilisateur(trice) connecté, et comme un compte expiré ne peut pas se connecter...)
- users.json : ajout de `utilisateur.expire`
- quelques modifs de style (sorry ca rend la PR compliqué à lire...)

![Screenshot 2020-07-31 at 11 05 06](https://user-images.githubusercontent.com/7147385/89019536-bad11b80-d31d-11ea-9e26-3c2db4df028b.png)
