### PR TITLE
Homogénéiser user name & id

### DIFF
--- a/betagouv.js
+++ b/betagouv.js
@@ -62,7 +62,7 @@ const betaOVH = {
     Promise.map(redirectionIds, redirectionId =>
       BetaGouv.requestRedirection(method, redirectionId)
     ),
-  redirectionsForName: async query => {
+  redirectionsForId: async query => {
     if (!query.from && !query.to) {
       throw new Error(`paramètre 'from' ou 'to' manquant`);
     }

--- a/betagouv.js
+++ b/betagouv.js
@@ -17,8 +17,8 @@ const config = {
 };
 
 const betaOVH = {
-  emailInfos: async name => {
-    const url = `/email/domain/${config.domain}/account/${name}`;
+  emailInfos: async id => {
+    const url = `/email/domain/${config.domain}/account/${id}`;
 
     try {
       return await ovh.requestPromised('GET', url, {});
@@ -28,14 +28,14 @@ const betaOVH = {
       throw new Error(`OVH Error GET on ${url} : ${JSON.stringify(err)}`);
     }
   },
-  createEmail: async (name, password) => {
+  createEmail: async (id, password) => {
     const url = `/email/domain/${config.domain}/account`;
 
     try {
-      console.log(`OVH POST ${url} name=${name}`);
+      console.log(`OVH POST ${url} name=${id}`);
 
       return await ovh.requestPromised('POST', url, {
-        accountName: name,
+        accountName: id,
         password
       });
     } catch (err) {

--- a/controllers/emailsController.js
+++ b/controllers/emailsController.js
@@ -55,7 +55,7 @@ module.exports.getEmails = async function (req, res) {
     const emails = await emailWithMetadataMemoized();
 
     res.render('emails', {
-      user: req.user,
+      currentUser: req.user,
       emails,
       partials: {
         header: 'header',
@@ -66,8 +66,8 @@ module.exports.getEmails = async function (req, res) {
     console.error(err);
 
     res.render('emails', {
+      currentUser: req.user,
       errors: ['Erreur interne'],
-      user: req.user,
       partials: {
         header: 'header',
         footer: 'footer'

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -8,7 +8,7 @@ function renderLogin(req, res, params) {
   params.partials = {
     header: 'header',
     footer: 'footer',
-    user: req.user
+    currentUser: req.user
   };
   params.domain = config.domain;
 

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -5,16 +5,16 @@ const buildBetaEmail = require('./utils').buildBetaEmail;
 const sendMail = require('./utils').sendMail;
 
 module.exports.getUsers = async function (req, res) {
-  if (req.query.name) {
-    return res.redirect(`/users/${req.query.name}`);
+  if (req.query.id) {
+    return res.redirect(`/users/${req.query.id}`);
   }
 
   try {
     const users = await BetaGouv.usersInfos();
 
     res.render('search', {
+      currentUser: req.user,
       users: users,
-      user: req.user,
       domain: config.domain,
       partials: {
         header: 'header',
@@ -25,11 +25,11 @@ module.exports.getUsers = async function (req, res) {
     console.error(err);
 
     res.render('search', {
+      currentUser: req.user,
       users: [],
       errors: [
         `Erreur interne: impossible de récupérer la liste des membres sur ${config.domain}`
       ],
-      user: req.user,
       partials: {
         header: 'header',
         footer: 'footer'
@@ -38,15 +38,14 @@ module.exports.getUsers = async function (req, res) {
   }
 }
 
-module.exports.getUserByName = async function (req, res) {
-  const name = req.params.name;
+module.exports.getUserById = async function (req, res) {
+  const id = req.params.id;
 
   try {
-    const user = await userInfos(name, req.user.id === name);
+    const user = await userInfos(id, req.user.id === id);
 
     res.render('user', {
-      name,
-      user: req.user,
+      currentUser: req.user,
       emailInfos: user.emailInfos,
       redirections: user.redirections,
       userInfos: user.userInfos,
@@ -127,7 +126,6 @@ module.exports.createEmailForUser = async function (req, res) {
 
 module.exports.createRedirectionForUser = async function (req, res) {
   const id = req.params.id;
-  const url = `${config.secure ? 'https' : 'http'}://${req.hostname}`;
 
   try {
     const user = await userInfos(id, req.user.id === id);
@@ -146,6 +144,8 @@ module.exports.createRedirectionForUser = async function (req, res) {
     console.log(
       `Création d'une redirection d'email id=${req.user.id}&from_email=${id}&to_email=${req.body.to_email}&createRedirection=${req.body.createRedirection}&keep_copy=${req.body.keep_copy}`
     );
+
+    const url = `${config.secure ? 'https' : 'http'}://${req.hostname}`;
 
     const message = `À la demande de ${req.user.id} sur <${url}>, je crée une redirection mail pour ${id}`;
 

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -33,12 +33,12 @@ module.exports.buildBetaEmail = function(id) {
   return `${id}@${config.domain}`;
 }
 
-module.exports.userInfos = async function(name, isCurrentUser) {
+module.exports.userInfos = async function(id, isCurrentUser) {
   try {
     const [userInfos, emailInfos, redirections] = await Promise.all([
-      BetaGouv.userInfosById(name),
-      BetaGouv.emailInfos(name),
-      BetaGouv.redirectionsForName({ from: name })
+      BetaGouv.userInfosById(id),
+      BetaGouv.emailInfos(id),
+      BetaGouv.redirectionsForId({ from: id })
     ]);
 
     const hasUserInfos = userInfos != undefined;
@@ -62,7 +62,6 @@ module.exports.userInfos = async function(name, isCurrentUser) {
       emailInfos,
       redirections,
       userInfos,
-      name,
       canCreateEmail,
       canCreateRedirection,
       canChangePassword

--- a/index.js
+++ b/index.js
@@ -68,12 +68,12 @@ app.use((err, req, res, next) => {
 });
 
 app.get('/', indexController.getIndex);
-app.get('/logout', logoutController.getLogout);
 app.get('/login', loginController.getLogin);
 app.post('/login', loginController.postLogin);
+app.get('/logout', logoutController.getLogout);
 app.get('/emails', emailsController.getEmails);
 app.get('/users', usersController.getUsers);
-app.get('/users/:name', usersController.getUserByName);
+app.get('/users/:id', usersController.getUserById);
 app.post('/users/:id/email', usersController.createEmailForUser);
 app.post('/users/:id/redirections', usersController.createRedirectionForUser);
 app.post('/users/:id/redirections/:email/delete', usersController.deleteRedirectionForUser);

--- a/tests/test-users.js
+++ b/tests/test-users.js
@@ -36,7 +36,7 @@ describe("Users", () => {
         .set('Cookie', `token=${utils.getJWT()}`)
         .end((err, res) => {
           res.text.should.include('<form action="/users">')
-          res.text.should.include('<input name="name"')
+          res.text.should.include('<input name="id"')
           res.text.should.include('<button>')
           done();
         })

--- a/views/footer.mustache
+++ b/views/footer.mustache
@@ -1,8 +1,8 @@
 </div>
-{{#user}}
+{{#currentUser}}
 <p id="bottom">
   Utilisateur : <a href="/users/{{id}}">{{id}}</a> / <a href="/emails">Tous les emails</a> / <a href="/logout">Déconnexion</a>
 </p>
-{{/user}}
+{{/currentUser}}
 </body>
 </html>

--- a/views/search.mustache
+++ b/views/search.mustache
@@ -1,8 +1,8 @@
 {{> header}}
 <form action="/users">
   <p>
-    <label><strong>Rechercher un nom</strong><br>
-    <input name="name" placeholder="prenom.nom" pattern="[a-z0-9_-]+.[a-z0-9_-]+" list="user_ids"></label><br>
+    <label><strong>Rechercher un nom</strong></label><br>
+    <input name="id" placeholder="prenom.nom" pattern="[a-z0-9_-]+.[a-z0-9_-]+" list="user_ids"><br>
     <i>Si le nom n'apparait pas en autocompletion, c'est que l'utilisateur n'existe pas sur {{domain}}</i>
   </p>
   <p>

--- a/views/user.mustache
+++ b/views/user.mustache
@@ -1,5 +1,5 @@
 {{> header}}
-<h1>{{name}}</h1>
+<h1>{{userInfos.id}}</h1>
 {{#errors}}
 <p style="color: red; font-weight: bold">{{errors}}<p>
 {{/errors}}
@@ -25,7 +25,7 @@
   {{^github}}Non renseigné{{/github}}</li>
 </ul>
 <p>
-  <i>Vous pouvez modifier la fiche sur Github : <a href="https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{name}}.md">Par ici</a></i>
+  <i>Vous pouvez modifier la fiche sur Github : <a href="https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/{{id}}.md">Par ici</a></i>
 </p>
 {{/userInfos}}
 {{^userInfos}}
@@ -37,10 +37,10 @@
 
 <h2>Compte mail</h2>
 {{#emailInfos}}
-  {{email}} ( <a href="https://mail.ovh.net/roundcube/?_user={{name}}@{{domain}}">Webmail</a> )
+  {{email}} ( <a href="https://mail.ovh.net/roundcube/?_user={{userInfos.id}}@{{domain}}">Webmail</a> )
   <p>Comment utiliser son compte email : <a href="https://docs.ovh.com/fr/emails/">Infos et tutos de configuration OVH</a></p>
   {{#canChangePassword}}
-    <form action="/users/{{name}}/password" method="POST">
+    <form action="/users/{{userInfos.id}}/password" method="POST">
       <fieldset>
         <legend>Changer le mot de passe POP/IMAP/SMTP</legend>
         <label>Nouveau mot de passe : <input name="new_password" type="password" required minlength="9"></label><br>
@@ -55,7 +55,7 @@
 {{/emailInfos}}
 {{#canCreateEmail}}
 <p>
-  <form action="/users/{{name}}/email" method="POST">
+  <form action="/users/{{userInfos.id}}/email" method="POST">
   <fieldset>
     <legend>Créer le compte mail</legend>
     <label>Envoyer le mot de passe à cette adresse mail : <br> <input name="to_email" type="email" required></label><br>
@@ -66,7 +66,7 @@
 {{/canCreateEmail}}
 {{^canCreateEmail}}
 <p>
-  <i>Seul {{name}} peut créer ou modifier ce compte email</i>
+  <i>Seul {{userInfos.id}} peut créer ou modifier ce compte email</i>
 </p>
 {{/canCreateEmail}}
 
@@ -75,7 +75,7 @@
 {{#redirections}}
   <li>
     {{from}} vers {{to}} {{#canCreateRedirection}}
-    <form action="/users/{{name}}/redirections/{{to}}/delete" method="POST">
+    <form action="/users/{{userInfos.id}}/redirections/{{to}}/delete" method="POST">
       <button>Supprimer</button>
     </form>
     {{/canCreateRedirection}}
@@ -87,7 +87,7 @@
 </ul>
 {{#canCreateRedirection}}
 <p>
-  <form action="/users/{{name}}/redirections" method="POST">
+  <form action="/users/{{userInfos.id}}/redirections" method="POST">
     <fieldset>
       <legend>Créer une redirection email</legend>
       <label>Rediriger les mails vers : <input name="to_email" type="email" required></label><br>
@@ -99,7 +99,7 @@
 {{/canCreateRedirection}}
 {{^canCreateRedirection}}
 <p>
-  <i>Seul {{name}} peut créer ou modifier les redirections</i>
+  <i>Seul {{userInfos.id}} peut créer ou modifier les redirections</i>
 </p>
 {{/canCreateRedirection}}
 {{> footer}}


### PR DESCRIPTION
Modifications apportées : 
- Utiliser user `id` partout (enlève `name` lorsqu'il apparait)
- Utiliser `currentUser` dans les templates lorsqu'on parle de `req.user` (`user` peut porter à confusion sinon)