### PR TITLE
UI v2 modifications additionnelles

### DIFF
--- a/tests/test-user.js
+++ b/tests/test-user.js
@@ -19,14 +19,28 @@ describe("User", () => {
     });
   });
 
-  describe("GET /users authenticated", () => {
-    it("should return a valid page", (done) => {
+  describe("GET /users/:id authenticated", () => {
+    it("should return a valid page for an existing user", (done) => {
       chai.request(app)
         .get('/users/utilisateur.parti')
         .set('Cookie', `token=${utils.getJWT()}`)
         .end((err, res) => {
           res.should.have.status(200);
           res.body.should.be.a('object');
+          done();
+        })
+    });
+    it("should return a valid page even for an unknown user", (done) => {
+      chai.request(app)
+        .get('/users/utilisateur.unknown')
+        .set('Cookie', `token=${utils.getJWT()}`)
+        .end((err, res) => {
+          res.should.have.status(200);
+          res.body.should.be.a('object');
+          res.text.should.include('Inexistante (nécessaire pour créer le compte mail)');
+          res.text.should.not.include('<form action="/users/utilisateur.unknown/email" method="POST">');
+          res.text.should.not.include('<form action="/users/utilisateur.unknown/password" method="POST">');
+          res.text.should.not.include('<form action="/users/utilisateur.unknown/redirections" method="POST">')
           done();
         })
     });
@@ -43,73 +57,120 @@ describe("User", () => {
           done();
         })
     });
-    it("should show the email creation form for email-less users", (done) => {
-      chai.request(app)
-        .get('/users/utilisateur.parti')
-        .set('Cookie', `token=${utils.getJWT()}`)
-        .end((err, res) => {
-          res.text.should.include('<form action="/users/utilisateur.parti/email" method="POST">');
-          done();
-        })
+    describe("email form", () => {
+      it("should show the email creation form for email-less users", (done) => {
+        chai.request(app)
+          .get('/users/utilisateur.parti')
+          .set('Cookie', `token=${utils.getJWT()}`)
+          .end((err, res) => {
+            res.text.should.include('Inexistant');
+            res.text.should.include('<form action="/users/utilisateur.parti/email" method="POST">');
+            res.text.should.not.include('<form action="/users/utilisateur.parti/password" method="POST">');
+            done();
+          })
+      });
+      it("should not show the email creation form for users with existing emails", (done) => {
+        nock.cleanAll()
+
+        nock(/.*ovh.com/)
+          .get(/^.*email\/domain\/.*\/account\/.*/)
+          .reply(200, { description: '' })
+
+        utils.mockUsers()
+        utils.mockOvhRedirections()
+        utils.mockOvhTime()
+
+        chai.request(app)
+          .get('/users/utilisateur.parti')
+          .set('Cookie', `token=${utils.getJWT()}`)
+          .end((err, res) => {
+            res.text.should.not.include('<form action="/users/utilisateur.parti/email" method="POST">');
+            res.text.should.include('Seul utilisateur.parti peut créer ou modifier ce compte email');
+            done();
+          })
+      });
+      it("should not show the email creation form for users expired", (done) => {
+        nock.cleanAll()
+
+        nock(/.*ovh.com/)
+          .get(/^.*email\/domain\/.*\/account\/.*/)
+          .reply(200, { description: '' })
+
+        utils.mockUsers()
+        utils.mockOvhRedirections()
+        utils.mockOvhTime()
+
+        chai.request(app)
+          .get('/users/utilisateur.expire')
+          .set('Cookie', `token=${utils.getJWT()}`)
+          .end((err, res) => {
+            res.text.should.not.include('<form action="/users/utilisateur.expire/email" method="POST">');
+            res.text.should.not.include('<form action="/users/utilisateur.expire/password" method="POST">');
+            res.text.should.include('Le compte utilisateur.expire est expiré.');
+            done();
+          })
+      });
+      it("should show the email password change form for current user with existing email", (done) => {
+        nock.cleanAll()
+
+        nock(/.*ovh.com/)
+          .get(/^.*email\/domain\/.*\/account\/.*/)
+          .reply(200, { description: '' })
+
+        utils.mockUsers()
+        utils.mockOvhRedirections()
+        utils.mockOvhTime()
+
+        chai.request(app)
+          .get('/users/utilisateur.actif')
+          .set('Cookie', `token=${utils.getJWT()}`)
+          .end((err, res) => {
+            res.text.should.not.include('<form action="/users/utilisateur.actif/email" method="POST">');
+            res.text.should.include('<form action="/users/utilisateur.actif/password" method="POST">');
+            done();
+          })
+      });
     });
-    it("should not show the email creation form for users with existing emails", (done) => {
-      nock.cleanAll()
+    describe("email redirection form", () => {
+      it("should show the email redirection form", (done) => {
+        chai.request(app)
+          .get('/users/utilisateur.actif')
+          .set('Cookie', `token=${utils.getJWT()}`)
+          .end((err, res) => {
+            res.text.should.include('<form action="/users/utilisateur.actif/redirections" method="POST">');
+            done();
+          })
+      });
+      it("should not show the email redirection form to other users", (done) => {
+        chai.request(app)
+          .get('/users/utilisateur.parti')
+          .set('Cookie', `token=${utils.getJWT()}`)
+          .end((err, res) => {
+            res.text.should.not.include('<form action="/users/utilisateur.parti/redirections" method="POST">')
+            res.text.should.include('Seul utilisateur.parti peut créer ou modifier les redirections')
+            done();
+          })
+      });
+      it("should not show the email redirection form for users expired", (done) => {
+        nock.cleanAll()
 
-      nock(/.*ovh.com/)
-        .get(/^.*email\/domain\/.*\/account\/.*/)
-        .reply(200, { description: '' })
+        nock(/.*ovh.com/)
+          .get(/^.*email\/domain\/.*\/account\/.*/)
+          .reply(200, { description: '' })
 
-      utils.mockUsers()
-      utils.mockOvhRedirections()
-      utils.mockOvhTime()
+        utils.mockUsers()
+        utils.mockOvhRedirections()
+        utils.mockOvhTime()
 
-      chai.request(app)
-        .get('/users/utilisateur.parti')
-        .set('Cookie', `token=${utils.getJWT()}`)
-        .end((err, res) => {
-          res.text.should.not.include('<form action="/users/utilisateur.parti/email" method="POST">');
-          res.text.should.include('Seul utilisateur.parti peut créer ou modifier ce compte email');
-          done();
-        })
-    });
-    it("should not show the email creation form for users expired", (done) => {
-      nock.cleanAll()
-
-      nock(/.*ovh.com/)
-        .get(/^.*email\/domain\/.*\/account\/.*/)
-        .reply(200, { description: '' })
-
-      utils.mockUsers()
-      utils.mockOvhRedirections()
-      utils.mockOvhTime()
-
-      chai.request(app)
-        .get('/users/utilisateur.expire')
-        .set('Cookie', `token=${utils.getJWT()}`)
-        .end((err, res) => {
-          res.text.should.not.include('<form action="/users/utilisateur.expire/email" method="POST">')
-          // res.text.should.include('Seul utilisateur.expire peut créer ou modifier ce compte email')
-          done();
-        })
-    });
-    it("should show an email redirection form", (done) => {
-      chai.request(app)
-        .get('/users/utilisateur.actif')
-        .set('Cookie', `token=${utils.getJWT()}`)
-        .end((err, res) => {
-          res.text.should.include('<form action="/users/utilisateur.actif/redirections" method="POST">')
-          done();
-        })
-    });
-    it("should not show an email redirection form to other users", (done) => {
-      chai.request(app)
-        .get('/users/utilisateur.parti')
-        .set('Cookie', `token=${utils.getJWT()}`)
-        .end((err, res) => {
-          res.text.should.include('Seul utilisateur.parti peut créer ou modifier les redirections')
-          res.text.should.not.include('<form action="/users/utilisateur.parti/redirections" method="POST">')
-          done();
-        })
+        chai.request(app)
+          .get('/users/utilisateur.expire')
+          .set('Cookie', `token=${utils.getJWT()}`)
+          .end((err, res) => {
+            res.text.should.not.include('<form action="/users/utilisateur.expire/redirections" method="POST">');
+            res.text.should.include('Le compte utilisateur.expire est expiré.');
+            done();
+          })
+      });
     });
   });
 

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -2,7 +2,9 @@
 
 <div class="container container-small">
 
-  <h4 class="subtitle"><%= userInfos.id %></h4>
+  <% if (userInfos) { %>
+    <h4 class="subtitle"><%= userInfos.id %></h4>
+  <% } %>
 
   <% if (errors.length) { %>
     <div class="notification error"><%= errors %></div>
@@ -18,7 +20,7 @@
       <ul>
         <li>Nom: <%= userInfos.fullname %></li>
         <li>Date de début: <%= userInfos.start %></li>
-        <li>Date de fin: <%= userInfos.end %> <% if (isExpired) { %><span class="text-red">Expiré !<span><% } %></li>
+        <li>Date de fin: <%= userInfos.end %> <% if (isExpired) { %><span class="text-red"><strong>Expiré !</strong><span><% } %></li>
         <li>Employeur: <%= userInfos.employer %></li>
         <li>Github : <% if (userInfos.github) { %><a href="https://github.com/<%= userInfos.github %>" target="_blank"><%= userInfos.github %></a><% } else { %>Non renseigné<% } %></li>
       </ul>
@@ -26,106 +28,112 @@
         ℹ️&nbsp;Une erreur ? Vous pouvez modifier la fiche sur Github <a href="https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/<%= userInfos.id %>.md" target="_blank"> ici</a>.
       </div>
     <% } else { %>
-      <p>
+      <div class="notification error">
         Inexistante (nécessaire pour créer le compte mail)<br>
         <i>Vous pouvez créer la fiche sur Github</i>
-      </p>
-    <% } %>
-  </div>
-
-  <div class="panel">
-    <h4>Compte mail</h4>
-
-    <% if (emailInfos) { %>
-      <%= emailInfos.email %> ( <a href="https://mail.ovh.net/roundcube/?_user=<%= userInfos.id %>@<%= domain %>">Webmail</a> )
-      <p>Comment utiliser son compte email : <a href="https://docs.ovh.com/fr/emails/">Infos et tutos de configuration OVH</a></p>
-      <% if (canChangePassword) { %>
-        <form action="/users/<%= userInfos.id %>/password" method="POST">
-          <fieldset>
-            <legend>Changer le mot de passe POP/IMAP/SMTP</legend>
-            <label>Nouveau mot de passe : </label><br>
-            <input name="new_password" type="password" minlength="9" required><br>
-            <i>(de 9 à 30 caractères, pas d'accents, pas d'espace au début ou à la fin)</i><br>
-            <button>Changer</button>
-          </fieldset>
-        </form>
-      <% } %>
-    <% } else { %>
-      <div><strong>Inexistant</strong></div>
-    <% } %>
-
-    <% if (canCreateEmail) { %>
-      <br>
-      <form action="/users/<%= userInfos.id %>/email" method="POST">
-      <fieldset>
-        <legend>Créer le compte mail</legend>
-        <div class="form__group">
-          <label>Envoyer le mot de passe à cette adresse mail : </label>
-          <input name="to_email" type="email" required>
-        </div>
-        <button class="button" type="submit">Créer un compte</button>
-        </fieldset>
-      </form>
-    <% } else { %>
-      <% if (isExpired) { %>
-        <p class="text-error">Le compte <%= userInfos.id %> est expiré.</p>
-      <% } else { %>
-        <div class="notification warning">
-          Seul <%= userInfos.id %> peut créer ou modifier ce compte email.
-        </div>
-      <% } %>
-    <% } %>
-  </div>
-
-  <div class="panel">
-    <h4>Redirections</h4>
-
-    <ul>
-      <% redirections.forEach(function(redirection) { %>
-        <li>
-          <%= redirection.from %> vers <%= redirection.to %>
-          <% if (canCreateRedirection) { %>
-            <form action="/users/<%= userInfos.id %>/redirections/<%= redirection.to %>/delete" method="POST">
-              <button class="button small no-margin" type="submit">Supprimer</button>
-            </form>
-          <% } %>
-        </li>
-      <% }) %>
-      <% if (redirections.length === 0) { %>
-        <li><strong>Aucune</strong></li>
-      <% } %>
-    </ul>
-
-    <% if (canCreateRedirection) { %>
-      <br>
-      <form action="/users/<%= userInfos.id %>/redirections" method="POST">
-        <fieldset>
-          <legend>Créer une redirection email</legend>
-          <div class="form__group">
-            <label>Rediriger les mails vers : </label>
-            <input name="to_email" type="email" required><br>
-          </div>
-          <div class="input__group">
-            <input type="checkbox" name="keep_copy" value="true"> <label>Garder une copie des emails si un compte existe</label>
-          </div>
-          <button class="button" type="submit">Créer la redirection</button>
-        </fieldset>
-      </form>
-    <% } else { %>
-      <% if (isExpired) { %>
-        <p class="text-error">Le compte <%= userInfos.id %> est expiré.</p>
-      <% } else { %>
-        <div class="notification warning">
-          Seul <%= userInfos.id %> peut créer ou modifier les redirections.
-        </div>
-      <% } %>
+      </div>
     <% } %>
   </div>
 
   <% if (userInfos) { %>
-  <div class="panel">
-    <h4>Marrainage</h4>
-    <p>
+    <div class="panel">
+      <h4>Compte mail</h4>
+
+      <% if (emailInfos) { %>
+        <%= emailInfos.email %> ( <a href="https://mail.ovh.net/roundcube/?_user=<%= userInfos.id %>@<%= domain %>">Webmail</a> )
+        <p>Comment utiliser son compte email : <a href="https://docs.ovh.com/fr/emails/">Infos et tutos de configuration OVH</a></p>
+        <% if (canChangePassword) { %>
+          <form action="/users/<%= userInfos.id %>/password" method="POST">
+            <fieldset>
+              <legend>Changer le mot de passe POP/IMAP/SMTP</legend>
+              <div class="form__group">
+                <label>Nouveau mot de passe : </label>
+                <input name="new_password" type="password" minlength="9" required>
+                <i>(de 9 à 30 caractères, pas d'accents, pas d'espace au début ou à la fin)</i>
+              </div>
+              <button class="button" type="submit">Changer</button>
+            </fieldset>
+          </form>
+        <% } %>
+      <% } else { %>
+        <div class="text-red"><strong>Inexistant</strong></div>
+      <% } %>
+
+      <br>
+      <% if (canCreateEmail) { %>
+        <form action="/users/<%= userInfos.id %>/email" method="POST">
+        <fieldset>
+          <legend>Créer le compte mail</legend>
+          <div class="form__group">
+            <label>Envoyer le mot de passe à cette adresse mail : </label>
+            <input name="to_email" type="email" required>
+          </div>
+          <button class="button" type="submit">Créer un compte</button>
+          </fieldset>
+        </form>
+      <% } else { %>
+        <% if (isExpired) { %>
+          <div class="notification error">
+            Le compte <%= userInfos.id %> est expiré.
+          </div>
+        <% } else { %>
+          <div class="notification warning">
+            Seul <%= userInfos.id %> peut créer ou modifier ce compte email.
+          </div>
+        <% } %>
+      <% } %>
+    </div>
+
+    <div class="panel">
+      <h4>Redirections</h4>
+
+      <ul>
+        <% redirections.forEach(function(redirection) { %>
+          <li>
+            <%= redirection.from %> vers <%= redirection.to %>
+            <% if (canCreateRedirection) { %>
+              <form action="/users/<%= userInfos.id %>/redirections/<%= redirection.to %>/delete" method="POST">
+                <button class="button small no-margin" type="submit">Supprimer</button>
+              </form>
+            <% } %>
+          </li>
+        <% }) %>
+        <% if (redirections.length === 0) { %>
+          <li><strong>Aucune</strong></li>
+        <% } %>
+      </ul>
+
+      <br>
+      <% if (canCreateRedirection) { %>
+        <form action="/users/<%= userInfos.id %>/redirections" method="POST">
+          <fieldset>
+            <legend>Créer une redirection email</legend>
+            <div class="form__group">
+              <label>Rediriger les mails vers : </label>
+              <input name="to_email" type="email" required>
+            </div>
+            <div class="input__group">
+              <input type="checkbox" name="keep_copy" value="true">
+              <label>Garder une copie des emails si un compte existe</label>
+            </div>
+            <button class="button" type="submit">Créer la redirection</button>
+          </fieldset>
+        </form>
+      <% } else { %>
+        <% if (isExpired) { %>
+          <div class="notification error">
+            Le compte <%= userInfos.id %> est expiré.
+          </div>
+        <% } else { %>
+          <div class="notification warning">
+            Seul <%= userInfos.id %> peut créer ou modifier les redirections.
+          </div>
+        <% } %>
+      <% } %>
+    </div>
+
+    <div class="panel">
+      <h4>Marrainage</h4>
       <form action="/marrainage" method="POST">
         <fieldset>
           <legend>Chercher un·e marrain·e</legend>
@@ -136,8 +144,7 @@
           <button class="button" type="submit">Chercher un·e marrain·e</button>
         </fieldset>
       </form>
-    </p>
-  </div>
+    </div>
   <% } %>
 
 <%- include('partials/footer'); -%>


### PR DESCRIPTION
Quelques éléments oubliés dans la PR précédente https://github.com/betagouv/secretariat/pull/114 que j'ai vu sur la version déployée ce matin:
- user template : 
  - enlever complètement `text-error`
  - mieux gérer le cas où `userInfos` est null (ca plantait sinon - test : https://secretariat.beta.gouv.fr/users/utilisateur.unknown )
  - une form et un button que j'avais oublié de modifier
- tests additionnels sur `/users/:id`