### PR TITLE
Ajouter un lien vers le repo Github dans le footer

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -2,11 +2,17 @@
     </main>
     <footer id="footer">
       <% if (currentUser) { %>
-        <a href="/users">Accueil</a> /
-        Utilisateur : <a href="/users/<%= currentUser.id %>"><%= currentUser.id %></a> /
-        <a href="/emails">Tous les emails</a> /
-        <a href="/logout">Se déconnecter</a>
+        <div style="margin-bottom: 10px;">
+          <a href="/users">Accueil</a> /
+          Utilisateur : <a href="/users/<%= currentUser.id %>"><%= currentUser.id %></a> /
+          <a href="/emails">Tous les emails</a> /
+          <a href="/logout">Se déconnecter</a>
+        </div>
       <% } %>
+      <div>
+        <img style="position: relative;top: 2px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAA5klEQVQ4jc3QMUuCURTG8V8tNQRGY45BS01OfQHH8EMEbUJ9iQga+yAFKo42BI3RYkRQkxKuCba9DZ6LF3nT3DxwuNzn+Z9zzz2sU3TwgrMFzHkw7TLzG0VkD/3QxnjFY+aPyxq8ZcCy/ExFm3HuYWvJF/PYwX4uXK/wespb2MjGPwzjHu+o4ST8JzwH04i6DxykCSZRfPGP8S+D/cnFUYiVuHdKCpO2G+yI2RIf4kyLLEoaFHNMLzePTb9xtXh6cBPs0bxRxxfucIoqtiOrpstrBVP/q3sFTXQxjJcmGITWNNvTmsQvxG9Kly7hW/kAAAAASUVORK5CYII="/>
+        <a href="https://github.com/betagouv/secretariat/" target="_blank">Github</a>
+      </div>
     </footer>
   </body>
 </html>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -11,7 +11,7 @@
       <% } %>
       <div>
         <img style="position: relative;top: 2px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAA5klEQVQ4jc3QMUuCURTG8V8tNQRGY45BS01OfQHH8EMEbUJ9iQga+yAFKo42BI3RYkRQkxKuCba9DZ6LF3nT3DxwuNzn+Z9zzz2sU3TwgrMFzHkw7TLzG0VkD/3QxnjFY+aPyxq8ZcCy/ExFm3HuYWvJF/PYwX4uXK/wespb2MjGPwzjHu+o4ST8JzwH04i6DxykCSZRfPGP8S+D/cnFUYiVuHdKCpO2G+yI2RIf4kyLLEoaFHNMLzePTb9xtXh6cBPs0bxRxxfucIoqtiOrpstrBVP/q3sFTXQxjJcmGITWNNvTmsQvxG9Kly7hW/kAAAAASUVORK5CYII="/>
-        Le code du secrétariat sur <a href="https://github.com/betagouv/secretariat/" target="_blank"> Github</a>
+        <a href="https://github.com/betagouv/secretariat/" target="_blank">Code source du secrétariat</a>
       </div>
     </footer>
   </body>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -11,7 +11,7 @@
       <% } %>
       <div>
         <img style="position: relative;top: 2px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABmJLR0QA/wD/AP+gvaeTAAAA5klEQVQ4jc3QMUuCURTG8V8tNQRGY45BS01OfQHH8EMEbUJ9iQga+yAFKo42BI3RYkRQkxKuCba9DZ6LF3nT3DxwuNzn+Z9zzz2sU3TwgrMFzHkw7TLzG0VkD/3QxnjFY+aPyxq8ZcCy/ExFm3HuYWvJF/PYwX4uXK/wespb2MjGPwzjHu+o4ST8JzwH04i6DxykCSZRfPGP8S+D/cnFUYiVuHdKCpO2G+yI2RIf4kyLLEoaFHNMLzePTb9xtXh6cBPs0bxRxxfucIoqtiOrpstrBVP/q3sFTXQxjJcmGITWNNvTmsQvxG9Kly7hW/kAAAAASUVORK5CYII="/>
-        <a href="https://github.com/betagouv/secretariat/" target="_blank">Github</a>
+        Le code du secrétariat sur <a href="https://github.com/betagouv/secretariat/" target="_blank"> Github</a>
       </div>
     </footer>
   </body>


### PR DESCRIPTION
J'ai mis le lien dans une nouvelle ligne pour le différencier des liens internes de l'app - ce qui emmène le footer à deux lignes. Le lien ouvre dans une nouvelle fenêtre/tab.

![image](https://user-images.githubusercontent.com/1225929/89621558-d3977f00-d891-11ea-9a4f-cd66611d0be7.png)
