### PR TITLE
Spécifier l'attribut SameSite des cookies token et session

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ app.set('views', path.join(__dirname, 'views'));
 app.use('/static', express.static('static'));
 
 app.use(cookieParser(config.secret));
-app.use(session({ cookie: { maxAge: 300000 } })); // Only used for Flash not safe for others purposes
+app.use(session({ cookie: { maxAge: 300000, sameSite: 'lax' } })); // Only used for Flash not safe for others purposes
 app.use(flash());
 
 app.use(bodyParser.urlencoded({ extended: false }));
@@ -47,7 +47,7 @@ app.use((req, res, next) => {
       expiresIn: '7 days'
     });
 
-    res.cookie('token', token);
+    res.cookie('token', token, { sameSite: 'lax' });
   }
 
   next();


### PR DESCRIPTION
Comme décrit dans l'issue #118, nous devons spécifier la politique _samesite_ des cookies qu'on envoie pour éviter des soucis avec les dernières versions de Firefox et Chrome.

Sur ce PR, j'ai mis le _samesite_ à `lax`, ce qui nous permet par exemple de faire un lien vers le secrétariat depuis un autre site (par ex _https://doc.incubateur.net/_) et de faire en sorte que l'utilisateur arrive au secrétariat avec son login (s'il était déjà logé bien sur). Dans une politique `strict`, le navigateur n'enverra pas les cookies si l'on accède au site depuis un lien externe - ce qui me semble trop contraignant. `lax` bloque bien l'envoie de cookies dans un site externe aussi, donc c'est mieux que `none`.