### PR TITLE
Utilise des promeses natives au lieu de Bluebird

### DIFF
--- a/betagouv.js
+++ b/betagouv.js
@@ -1,6 +1,5 @@
 // betagouv.js
 // ======
-const Promise = require('bluebird');
 const https = require('https');
 const rp = require('request-promise');
 const ovh = require('ovh')({
@@ -58,10 +57,9 @@ const betaOVH = {
       method,
       `/email/domain/${config.domain}/redirection/${redirectionId}`
     ),
-  requestRedirections: async (method, redirectionIds) =>
-    Promise.map(redirectionIds, redirectionId =>
-      BetaGouv.requestRedirection(method, redirectionId)
-    ),
+  requestRedirections: async (method, redirectionIds) => {
+    return Promise.all(redirectionIds.map(x => BetaGouv.requestRedirection(method, x)))
+  },
   redirectionsForId: async query => {
     if (!query.from && !query.to) {
       throw new Error(`paramètre 'from' ou 'to' manquant`);

--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -1,6 +1,5 @@
 const config = require('../config');
 const BetaGouv = require('../betagouv');
-const Promise = require('bluebird');
 const nodemailer = require('nodemailer');
 
 const mailTransport = nodemailer.createTransport({


### PR DESCRIPTION
Ce PR adresse l'issue #89 

Il faut noter que notre package.json n'inclut pas Bluebird comme dépendance, Bluebird est seulement présent en tant que dépendance d'OVH.