### PR TITLE
Ajoute un lien au titre du header

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -30,15 +30,13 @@ fieldset {
 
 /* custom css */
 
-/* adds a 'opens in new tab' icon */
-a[target="_blank"]::after {
-  content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
-  margin: 0 3px 0 5px;
-}
-
 #header, #footer {
   /* color: rgba(0,0,0,0.4); */
   margin: 1em;
+  text-align: center;
+}
+
+.text-center {
   text-align: center;
 }
 
@@ -168,6 +166,18 @@ button.button-underline, button.button-underline:active, button.button-underline
 
 a.button[target="_blank"]::after {
   content:  url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKBAMAAAB/HNKOAAAAD1BMVEUAAACjo6Pn5+fDw8P///8mXC3WAAAABHRSTlMAfb49zZRSvgAAADBJREFUCNdjAAIXFxBicmFwYGAQUQGSjI4sQFJEgIHBgdmRAUgyGAAxUBZOugCBAwCrDAY9nvSvKAAAAABJRU5ErkJggg==');
+}
+
+/* adds a 'opens in new tab' icon */
+a[target="_blank"]::after {
+  content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+  margin: 0 3px 0 5px;
+}
+
+a.no-decoration {
+  text-decoration: none;
+  background-color: transparent;
+  color: inherit;
 }
 
 .redirection-form {

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -11,13 +11,14 @@
     <% } %>
 
     <div class="panel margin-top-m">
-
-        <div class="beta-banner"></div>
-
         <h3>Créer ma fiche Github</h3>
 
-        <p>Bienvenue dans la communauté</p>
-        <p>Crée ta fiche Github pour avoir accès aux différents outils de la communauté</p>
+        <p>
+            Bienvenue dans la communauté !<br>
+            Crée ta fiche Github pour avoir accès aux différents outils de la communauté
+        </p>
+
+        <div class="beta-banner"></div>
 
         <form action="/onboarding" method="POST">
             <h4>Tes infos persos</h4>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -15,7 +15,9 @@
   </head>
   <body>
     <header id="header">
-      <h3>🤖&nbsp;Secrétariat automatique de BetaGouv</h3>
+      <a class="no-decoration" href="/">
+        <h3>🤖&nbsp;Secrétariat automatique de BetaGouv</h3>
+      </a>
     </header>
     <main role="main">
       <section class="section section-grey no-padding">


### PR DESCRIPTION
- Voir l'issue https://github.com/betagouv/secretariat/issues/179 (pouvoir revenir en arrière sur la page d'onboarding)
- Le lien est "invisible", seul le hover indique que c'est bien un lien, pour maintenir le rendu visuel
- Je ne l'ai pas fait sur le nav-header car c'est un peu plus compliqué (pas mal de css au niveau du logo qui casserait), mais je peux le rajouter