### PR TITLE
Onboarding : meilleure gestion des erreurs et validations supplémentaires sur les dates

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,11 +1,21 @@
 const isSecure = (process.env.SECURE || 'true') === 'true';
 
+const memberStatusOptions = [
+  { name: 'Indépendant', value: 'independent' },
+  { name: 'Administration (agent public)', value: 'admin' },
+  { name: 'Société de service', value: 'service' },
+];
+
 module.exports = {
   secret: process.env.SESSION_SECRET,
   secure: isSecure,
   protocol: isSecure ? 'https' : 'http',
   port: process.env.PORT || 8100,
   domain: process.env.SECRETARIAT_DOMAIN || "beta.gouv.fr",
+  member: {
+    statusOptions: memberStatusOptions,
+    minStartDate: "2013-07-01"
+  },
   senderEmail: process.env.MAIL_SENDER || "secretariat@incubateur.net",
   githubToken: process.env.GITHUB_TOKEN,
   githubRepository: process.env.GITHUB_REPOSITORY,

--- a/controllers/onboardingController.js
+++ b/controllers/onboardingController.js
@@ -43,6 +43,18 @@ module.exports.getForm = async function (req, res) {
     res.render('onboarding', {
       errors: req.flash('error'),
       messages: req.flash('message'),
+      formData: {
+        firstName: "",
+        lastName: "",
+        website: "",
+        github: "",
+        role: "",
+        start: new Date().toISOString().split('T')[0], // YYYY-MM-DD
+        end: "",
+        status: "",
+        startup: "",
+        employer: ""
+      }
     });
   } catch (err) {
     console.error(err);
@@ -51,20 +63,49 @@ module.exports.getForm = async function (req, res) {
 }
 module.exports.postForm = async function (req, res) {
   try {
-    function throwValidationError(field) {
-      throw new Error(`Le champ ${field} n'est pas renseigné`);
+    formValidationErrors = [];
+
+    function requiredError(field) {
+      formValidationErrors.push(`${field} : le champ n'est pas renseigné`);
     }
 
-    const firstName = req.body.firstName || throwValidationError('prénom');
-    const lastName = req.body.lastName || throwValidationError('nom de famille');
+    function isValidDate(field, date) {
+      if (date instanceof Date && !isNaN(date)) {
+        console.log(date)
+        return date;
+      } else {
+        formValidationErrors.push(`${field} : la date n'est pas valide`);
+        return null;
+      }
+    }
+
+    const firstName = req.body.firstName || requiredError('prénom');
+    const lastName = req.body.lastName || requiredError('nom de famille');
     const website = req.body.website || null;
     const github = req.body.github || null;
-    const role = req.body.role || throwValidationError('role');
-    const start = req.body.start || throwValidationError('début de la mission');
-    const end = req.body.end || throwValidationError('fin de la mission');
-    const status = req.body.status || throwValidationError('statut');
+    const role = req.body.role || requiredError('role');
+    const start = req.body.start || requiredError('début de la mission');
+    const end = req.body.end || requiredError('fin de la mission');
+    const status = req.body.status || requiredError('statut');
     const startup = req.body.startup || null;
     const employer = req.body.employer || null;
+
+    // check start & end dates
+    startDate = isValidDate('date de début', new Date(start));
+    endDate = isValidDate('date de fin', new Date(end));
+    if (startDate && endDate) {
+      if (startDate.getFullYear() < 2020) {
+        formValidationErrors.push('date de début : l\'année doit être au moins 2020');
+      }
+      if (endDate < startDate) {
+        formValidationErrors.push('dates : la date de fin doit être supérieure à la date de début');
+      }
+    }
+
+    if (formValidationErrors.length) {
+      req.flash('error', formValidationErrors);
+      throw new Error();
+    }
 
     const name = `${firstName} ${lastName}`;
     const username = utils.createUsername(firstName, lastName);
@@ -83,9 +124,11 @@ module.exports.postForm = async function (req, res) {
     res.redirect('/onboardingSuccess');
 
   } catch (err) {
-    console.error(err);
-    req.flash('error', err.message);
-    return res.redirect('/onboarding');
+    res.render('onboarding', {
+      errors: req.flash('error'),
+      messages: req.flash('message'),
+      formData: req.body
+    });
   }
 }
 module.exports.getConfirmation = async function (req, res) {

--- a/controllers/onboardingController.js
+++ b/controllers/onboardingController.js
@@ -63,7 +63,7 @@ module.exports.getForm = async function (req, res) {
 }
 module.exports.postForm = async function (req, res) {
   try {
-    formValidationErrors = [];
+    var formValidationErrors = [];
 
     function requiredError(field) {
       formValidationErrors.push(`${field} : le champ n'est pas renseigné`);
@@ -71,7 +71,6 @@ module.exports.postForm = async function (req, res) {
 
     function isValidDate(field, date) {
       if (date instanceof Date && !isNaN(date)) {
-        console.log(date)
         return date;
       } else {
         formValidationErrors.push(`${field} : la date n'est pas valide`);

--- a/controllers/onboardingController.js
+++ b/controllers/onboardingController.js
@@ -1,7 +1,8 @@
-const config = require('../config');
 const ejs = require('ejs');
-const utils = require('./utils');
 const crypto = require('crypto');
+
+const config = require('../config');
+const utils = require('./utils');
 
 function createBranchName(username) {
   const refRegex = /( |\.|\\|~|^|:|\?|\*|\[)/gm;
@@ -43,6 +44,7 @@ module.exports.getForm = async function (req, res) {
     res.render('onboarding', {
       errors: req.flash('error'),
       messages: req.flash('message'),
+      memberConfig: config.member,
       formData: {
         firstName: "",
         lastName: "",
@@ -93,8 +95,8 @@ module.exports.postForm = async function (req, res) {
     startDate = isValidDate('date de début', new Date(start));
     endDate = isValidDate('date de fin', new Date(end));
     if (startDate && endDate) {
-      if (startDate.getFullYear() < 2020) {
-        formValidationErrors.push('date de début : l\'année doit être au moins 2020');
+      if (startDate < new Date(config.member.minStartDate)) {
+        formValidationErrors.push('date de début : l\'année doit être au moins 2013');
       }
       if (endDate < startDate) {
         formValidationErrors.push('dates : la date de fin doit être supérieure à la date de début');

--- a/tests/test-onboarding.js
+++ b/tests/test-onboarding.js
@@ -74,6 +74,26 @@ describe('Onboarding', () => {
         .send({
           lastName: 'Úñíbe',
           role: 'Dev',
+          start: 'aaaa-bb-cc',
+          end: '2021-01-01',
+          status: 'Independant'
+        })
+        .end((err, res) => {
+          this.getGithubMasterSha.called.should.be.false;
+          this.createGithubBranch.called.should.be.false;
+          this.createGithubFile.called.should.be.false;
+          this.makeGithubPullRequest.called.should.be.false;
+          done();
+        });
+    });
+
+    it("should not call Github API if a date doesn't exist", (done) => {
+      chai.request(app)
+        .post('/onboarding')
+        .type('form')
+        .send({
+          lastName: 'Úñíbe',
+          role: 'Dev',
           start: '2020-42-42',
           end: '2021-01-01',
           status: 'Independant'

--- a/tests/test-onboarding.js
+++ b/tests/test-onboarding.js
@@ -67,6 +67,66 @@ describe('Onboarding', () => {
         });
     });
 
+    it("should not call Github API if a date is wrong", (done) => {
+      chai.request(app)
+        .post('/onboarding')
+        .type('form')
+        .send({
+          lastName: 'Úñíbe',
+          role: 'Dev',
+          start: '2020-42-42',
+          end: '2021-01-01',
+          status: 'Independant'
+        })
+        .end((err, res) => {
+          this.getGithubMasterSha.called.should.be.false;
+          this.createGithubBranch.called.should.be.false;
+          this.createGithubFile.called.should.be.false;
+          this.makeGithubPullRequest.called.should.be.false;
+          done();
+        });
+    });
+
+    it("should not call Github API if the end date is smaller than the start date", (done) => {
+      chai.request(app)
+        .post('/onboarding')
+        .type('form')
+        .send({
+          lastName: 'Úñíbe',
+          role: 'Dev',
+          start: '2020-12-31',
+          end: '2021-01-01',
+          status: 'Independant'
+        })
+        .end((err, res) => {
+          this.getGithubMasterSha.called.should.be.false;
+          this.createGithubBranch.called.should.be.false;
+          this.createGithubFile.called.should.be.false;
+          this.makeGithubPullRequest.called.should.be.false;
+          done();
+        });
+    });
+
+    it("should not call Github API if the start date is too small", (done) => {
+      chai.request(app)
+        .post('/onboarding')
+        .type('form')
+        .send({
+          lastName: 'Úñíbe',
+          role: 'Dev',
+          start: '2000-01-01',
+          end: '2021-01-01',
+          status: 'Independant'
+        })
+        .end((err, res) => {
+          this.getGithubMasterSha.called.should.be.false;
+          this.createGithubBranch.called.should.be.false;
+          this.createGithubFile.called.should.be.false;
+          this.makeGithubPullRequest.called.should.be.false;
+          done();
+        });
+    });
+
     it("should call Github API if mandatory fields are present", (done) => {
       chai.request(app)
         .post('/onboarding')

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -38,7 +38,7 @@
                 <label for="lastName">
                     <strong>Nom de famille (obligatoire)</strong>
                 </label>
-                <input name="lastName"  value="<%= formData.lastName %>" required>
+                <input name="lastName" value="<%= formData.lastName %>" required>
             </div>
 
             <div class="form__group">
@@ -47,7 +47,7 @@
                     Il sera affiché sur la page <a href="https://beta.gouv.fr/communaute/"
                         target="_blank">Communauté</a> du site BetaGouv.
                 </label>
-                <input name="website"  value="<%= formData.website %>">
+                <input name="website" value="<%= formData.website %>">
             </div>
 
             <div class="form__group">
@@ -55,7 +55,7 @@
                     <span>Utilisateur Github</span><br />
                     Si tu as un compte, tu peux être ajouté à l'organisation Github BetaGouv
                 </label>
-                <input name="github"  value="<%= formData.github %>">
+                <input name="github" value="<%= formData.github %>">
             </div>
 
 
@@ -65,23 +65,22 @@
                     <strong>Ton rôle chez BetaGouv (obligatoire)</strong><br />
                     Développeuse, Intrapreneur, Chargée de déploiement, Coach, UX Designer...
                 </label>
-                <input name="role"  value="<%= formData.role %>" required>
+                <input name="role" value="<%= formData.role %>" required>
             </div>
 
             <div class="form__group">
                 <label for="start">
                     <strong>Début de ta mission (obligatoire)</strong><br />
-                    En format YYY-MM-DD, par exemple : 2020-01-31
                 </label>
-                <input pattern="^\d{4}-\d{2}-\d{2}$" name="start" value="<%= formData.start %>" required>
+                <input type="date" name="start" pattern="^\d{4}-\d{2}-\d{2}$" min="2020-01-01" title="En format YYY-MM-DD, par exemple : 2020-01-31" value="<%= formData.start %>" required>
             </div>
 
             <div class="form__group">
                 <label for="end">
                     <strong>Fin de ta mission (obligatoire)</strong><br />
-                    En format YYY-MM-DD, par exemple : 2020-01-31
+                    
                 </label>
-                <input pattern="^\d{4}-\d{2}-\d{2}$" name="end" value="<%= formData.end %>" required>
+                <input type="date" name="end" pattern="^\d{4}-\d{2}-\d{2}$" value="<%= formData.end %>" title="En format YYY-MM-DD, par exemple : 2020-01-31" required>
             </div>
 
             <div class="form__group">
@@ -106,7 +105,7 @@
                     <span>Ton employeur</span><br />
                     L'entité avec laquelle tu as signé ton contrat (DINUM, Octo...)
                 </label>
-                <input name="employer"  value="<%= formData.employer %>">
+                <input name="employer" value="<%= formData.employer %>">
             </div>
 
 

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -3,7 +3,11 @@
 <div class="container container-small">
 
     <% if (errors.length) { %>
-    <div class="notification error"><%= errors %></div>
+    <div class="notification error">
+        <% errors.forEach(function(error) { %>
+            <li><%= error %></li>
+        <% }) %>
+    </div>
     <% } %>
 
     <% if (messages.length) { %>
@@ -30,11 +34,11 @@
                 <label for="firstName">
                     <strong>Prénom (obligatoire)</strong>
                 </label>
-                <input name="firstName" required>
+                <input name="firstName" value="<%= formData.firstName %>" required>
                 <label for="lastName">
                     <strong>Nom de famille (obligatoire)</strong>
                 </label>
-                <input name="lastName" required>
+                <input name="lastName"  value="<%= formData.lastName %>" required>
             </div>
 
             <div class="form__group">
@@ -43,7 +47,7 @@
                     Il sera affiché sur la page <a href="https://beta.gouv.fr/communaute/"
                         target="_blank">Communauté</a> du site BetaGouv.
                 </label>
-                <input name="website">
+                <input name="website"  value="<%= formData.website %>">
             </div>
 
             <div class="form__group">
@@ -51,7 +55,7 @@
                     <span>Utilisateur Github</span><br />
                     Si tu as un compte, tu peux être ajouté à l'organisation Github BetaGouv
                 </label>
-                <input name="github">
+                <input name="github"  value="<%= formData.github %>">
             </div>
 
 
@@ -61,7 +65,7 @@
                     <strong>Ton rôle chez BetaGouv (obligatoire)</strong><br />
                     Développeuse, Intrapreneur, Chargée de déploiement, Coach, UX Designer...
                 </label>
-                <input name="role" required>
+                <input name="role"  value="<%= formData.role %>" required>
             </div>
 
             <div class="form__group">
@@ -69,7 +73,7 @@
                     <strong>Début de ta mission (obligatoire)</strong><br />
                     En format YYY-MM-DD, par exemple : 2020-01-31
                 </label>
-                <input pattern="^\d{4}-\d{2}-\d{2}$" name="start" required>
+                <input pattern="^\d{4}-\d{2}-\d{2}$" name="start" value="<%= formData.start %>" required>
             </div>
 
             <div class="form__group">
@@ -77,23 +81,24 @@
                     <strong>Fin de ta mission (obligatoire)</strong><br />
                     En format YYY-MM-DD, par exemple : 2020-01-31
                 </label>
-                <input pattern="^\d{4}-\d{2}-\d{2}$" name="end" required>
+                <input pattern="^\d{4}-\d{2}-\d{2}$" name="end" value="<%= formData.end %>" required>
             </div>
 
             <div class="form__group">
                 <label for="status">
                     <strong>Ton statut (obligatoire)</strong><br />
                 </label>
-                <input type="radio" required name="status" value="independent">Indépendant<br>
-                <input type="radio" required name="status" value="admin">Administration (agent public)<br>
-                <input type="radio" required name="status" value="service">Société de service<br>
+                <% var options = [{ name: 'Indépendant', value: 'independent' }, { name: 'Administration (agent public)', value: 'admin' }, { name: 'Société de service', value: 'service' }]; %>
+                <% options.forEach(function(option) { %>
+                    <input type="radio" name="status" value="<%= option.value %>" <%= (option.value === formData.status) ? 'checked' : '' %> required><%= option.name %><br>
+                <% }) %>
             </div>
 
             <div class="form__group">
                 <label for="startup">
                     <span>Ta Startup d'État</span><br />
                 </label>
-                <input name="startup">
+                <input name="startup" value="<%= formData.startup %>">
             </div>
 
             <div class="form__group">
@@ -101,7 +106,7 @@
                     <span>Ton employeur</span><br />
                     L'entité avec laquelle tu as signé ton contrat (DINUM, Octo...)
                 </label>
-                <input name="employer">
+                <input name="employer"  value="<%= formData.employer %>">
             </div>
 
 

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -72,7 +72,7 @@
                 <label for="start">
                     <strong>Début de ta mission (obligatoire)</strong><br />
                 </label>
-                <input type="date" name="start" pattern="^\d{4}-\d{2}-\d{2}$" min="2020-01-01" title="En format YYY-MM-DD, par exemple : 2020-01-31" value="<%= formData.start %>" required>
+                <input type="date" name="start" pattern="^\d{4}-\d{2}-\d{2}$" min="<%= memberConfig.minStartDate %>" value="<%= formData.start %>" title="En format YYYY-MM-DD, par exemple : 2020-01-31" required>
             </div>
 
             <div class="form__group">
@@ -80,15 +80,14 @@
                     <strong>Fin de ta mission (obligatoire)</strong><br />
                     
                 </label>
-                <input type="date" name="end" pattern="^\d{4}-\d{2}-\d{2}$" value="<%= formData.end %>" title="En format YYY-MM-DD, par exemple : 2020-01-31" required>
+                <input type="date" name="end" pattern="^\d{4}-\d{2}-\d{2}$" value="<%= formData.end %>" title="En format YYYY-MM-DD, par exemple : 2020-01-31" required>
             </div>
 
             <div class="form__group">
                 <label for="status">
                     <strong>Ton statut (obligatoire)</strong><br />
                 </label>
-                <% var options = [{ name: 'Indépendant', value: 'independent' }, { name: 'Administration (agent public)', value: 'admin' }, { name: 'Société de service', value: 'service' }]; %>
-                <% options.forEach(function(option) { %>
+                <% memberConfig.statusOptions.forEach(function(option) { %>
                     <input type="radio" name="status" value="<%= option.value %>" <%= (option.value === formData.status) ? 'checked' : '' %> required><%= option.name %><br>
                 <% }) %>
             </div>


### PR DESCRIPTION
Modifications apportées
- Garde le formulaire rempli en cas d'erreurs (voir l'issue https://github.com/betagouv/secretariat/issues/170)
- Ajout de `type=date` aux champs start & end (partie 1 de l'issue https://github.com/betagouv/secretariat/issues/171)
  - si ce type n'est pas géré par le browser, le fallback revient à un input text classique. J'ai donc laissé le pattern, et basculé le message de YYYY-MM-DD dans le title (il s'affichera si le pattern renvoie une erreur de validation)
- Validations supplémentaires sur le champs date (partie 2 de l'issue https://github.com/betagouv/secretariat/issues/171). Certaines de ces validations sont gérés par le datepicker, mais on ne sait jamais :)
  - vérifier que les dates fournies existent bien (éviter les 2020-30-12 au lieu de 2020-12-30)
  - vérifier que start < end
  - vérifier que start est au moins 2020
- Défini une date de début par défaut à aujourd'hui au lancement du formulaire
- Ajout de quelques tests

Conflits probables avec la PR https://github.com/betagouv/secretariat/pull/182