### PR TITLE
Pouvoir accéder au formulaire Onboarding depuis la page Communauté

### DIFF
--- a/views/community.ejs
+++ b/views/community.ejs
@@ -16,9 +16,13 @@
                 </datalist>
             </div>
             <div class="form__group">
-            <button class="button no-margin" type="submit">Voir la fiche</button>
+                <button class="button no-margin" type="submit">Voir la fiche</button>
             </div>
         </form>
+        <br />
+        <p>
+            Le membre que vous cherchez n'existe pas ? Vous pouvez créer sa fiche Github <a href="/onboarding">en cliquant ici</a>.
+        </p>
     </div>
 
 


### PR DESCRIPTION
Issue https://github.com/betagouv/secretariat/issues/198

Rajout de la ligne en dessous du bouton "Voir la fiche". Wording similaire aux modifications de https://github.com/betagouv/secretariat/pull/202

<img width="1183" alt="Screenshot 2020-10-15 at 14 10 12" src="https://user-images.githubusercontent.com/7147385/96121298-2de73880-0ef0-11eb-9c88-0be8f17972f6.png">
