### PR TITLE
Évite l'exposition des fichiers privés via node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
 app.use('/static', express.static('static'));
-app.use('/~', express.static(path.join(__dirname, 'node_modules'))); // hack to mimick the behavior of webpack css-loader (used to import template.data.gouv.fr)
+app.use('/datagouvfr', express.static(path.join(__dirname, 'node_modules/template.data.gouv.fr/dist'))); // hack to mimick the behavior of webpack css-loader (used to import template.data.gouv.fr)
 
 app.use(cookieParser(config.secret));
 app.use(session({ cookie: { maxAge: 300000, sameSite: 'lax' } })); // Only used for Flash not safe for others purposes

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,4 +1,4 @@
-@import "/~/template.data.gouv.fr/dist/main.css";
+@import "/datagouvfr/main.css";
 
 
 /* override template.min.css */


### PR DESCRIPTION
En exposant node_modules certains fichiers privés sont exposés ([owasp,](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure.html)). Présent dans le code-scan aussi.