### PR TITLE
Enlève les appels API innécessaires sur la homepage

### DIFF
--- a/controllers/communityController.js
+++ b/controllers/communityController.js
@@ -9,12 +9,10 @@ module.exports.getCommunity = async function (req, res) {
   }
   try {
     const users = await BetaGouv.usersInfos();
-    const currentUser = await utils.userInfos(req.user.id, true);
     res.render('community', {
       currentUserId: req.user.id,
       domain: config.domain,
       users: users,
-      userInfos: currentUser.userInfos,
       activeTab: 'community',
       errors: req.flash('error'),
       messages: req.flash('message')

--- a/views/partials/nav-header.ejs
+++ b/views/partials/nav-header.ejs
@@ -41,7 +41,7 @@
                 </li>
                 <li class="nav-end">
                     <hr />
-                    <% if (userInfos) { %>
+                    <% if (currentUserId) { %>
                     <div>
                         Identifié·e en tant que<br />
                         <span class="font-weight-bold"><%= currentUserId %></span>


### PR DESCRIPTION
Aujourd'hui on fait des calls réseau pour obtenir les _userInfos_, _emailInfos_ et _redirections_ pour l'utilisateur identifié quand on charge la homepage (_/community_). Le résultat de ces calls n'est pas utilisé dans la view.