### PR TITLE
Ajout du bouton pour le départ d'un membre

### DIFF
--- a/betagouv.js
+++ b/betagouv.js
@@ -35,6 +35,17 @@ const betaOVH = {
       throw new Error(`OVH Error POST on ${url} : ${JSON.stringify(err)}`);
     }
   },
+  deleteEmail: async (id, password) => {
+    const url = `/email/domain/${config.domain}/account/${id}`;
+
+    try {
+      console.log(`OVH DELETE ${url}`);
+
+      return await ovh.requestPromised('DELETE', url);
+    } catch (err) {
+      throw new Error(`OVH Error DELETE on ${url} : ${JSON.stringify(err)}`);
+    }
+  },
   createRedirection: async (from, to, localCopy) => {
     const url = `/email/domain/${config.domain}/redirection`;
 

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -240,11 +240,11 @@ module.exports.deleteEmailForUser = async function(req, res) {
       res.redirect('/login');
     } else {
       req.flash('message', `Le compte email de ${id} a bien été supprimé.`);
-      res.redirect('/community');
+      res.redirect(`/community/${id}`);
     }
   } catch (err) {
     console.error(err);
     req.flash('error', err.message);
-    res.redirect(`/community`);
+    res.redirect(`/community/${id}`);
   }
 }

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -224,6 +224,8 @@ module.exports.deleteEmailForUser = async function(req, res) {
       );
     }
 
+    await BetaGouv.sendInfoToSlack(`Suppression de compte de ${id} (à la demande de ${req.user.id})`);
+
     if (user.redirections && user.redirections.length > 0) {
       await BetaGouv.requestRedirections('DELETE', user.redirections.map(x=> x.id));
       console.log(`Supression des redirections de l'email de ${id} (à la demande de ${req.user.id})`);

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -210,3 +210,39 @@ module.exports.updatePasswordForUser = async function (req, res) {
     res.redirect(`/community/${id}`);
   }
 }
+
+module.exports.deleteEmailForUser = async function(req, res) {
+  const id = req.params.id;
+  const isCurrentUser = req.user.id === id;
+
+  try {
+    const user = await utils.userInfos(id, isCurrentUser);
+
+    if (!user.isExpired) {
+      throw new Error(
+        `Le compte de ${id} n'est pas expiré, vous ne pouvez pas supprimer son compte.`
+      );
+    }
+
+    if (user.redirections && user.redirections.length > 0) {
+      await BetaGouv.requestRedirections('DELETE', user.redirections.map(x=> x.id));
+      console.log(`Supression des redirections de l'email de ${id} (à la demande de ${req.user.id})`);
+    }
+
+    await BetaGouv.deleteEmail(id);
+    console.log(`Supression de compte email de ${id} (à la demande de ${req.user.id})`);
+
+    if (isCurrentUser) {
+      res.clearCookie('token')
+      req.flash('message', `Ton compte email a bien été supprimé.`);
+      res.redirect('/login');
+    } else {
+      req.flash('message', `Le compte email de ${id} a bien été supprimé.`);
+      res.redirect('/community');
+    }
+  } catch (err) {
+    console.error(err);
+    req.flash('error', err.message);
+    res.redirect(`/community`);
+  }
+}

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -218,9 +218,9 @@ module.exports.deleteEmailForUser = async function(req, res) {
   try {
     const user = await utils.userInfos(id, isCurrentUser);
 
-    if (!user.isExpired) {
+    if (!isCurrentUser && !user.isExpired) {
       throw new Error(
-        `Le compte de ${id} n'est pas expiré, vous ne pouvez pas supprimer son compte.`
+        `Le compte "${id}" n'est pas expiré, vous ne pouvez pas supprimer ce compte.`
       );
     }
 

--- a/index.js
+++ b/index.js
@@ -114,6 +114,7 @@ app.get('/login', loginController.getLogin);
 app.post('/login', loginController.postLogin);
 app.get('/logout', logoutController.getLogout);
 app.post('/users/:id/email', usersController.createEmailForUser);
+app.post('/users/:id/email/delete', usersController.deleteEmailForUser);
 app.post('/users/:id/redirections', usersController.createRedirectionForUser);
 app.post('/users/:id/redirections/:email/delete', usersController.deleteRedirectionForUser);
 app.post('/users/:id/password', usersController.updatePasswordForUser);

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -112,7 +112,7 @@ fieldset {
   min-width: 45%;
 }
 
-.panel p, .panel label {
+.panel p, .panel label, .panel li {
   color: #53657d;
   margin-top: 0;
 }

--- a/tests/test-user.js
+++ b/tests/test-user.js
@@ -461,6 +461,7 @@ describe("User", () => {
       utils.mockOvhTime()
       utils.mockOvhUserEmailInfos()
       utils.mockOvhAllEmailInfos()
+      utils.mockSlack()
 
       let ovhRedirectionDeletion = nock(/.*ovh.com/)
         .delete(/^.*email\/domain\/.*\/redirection\/123123/)
@@ -512,6 +513,7 @@ describe("User", () => {
       utils.mockOvhTime()
       utils.mockOvhUserEmailInfos()
       utils.mockOvhAllEmailInfos()
+      utils.mockSlack()
 
       let ovhRedirectionDeletion = nock(/.*ovh.com/)
         .delete(/^.*email\/domain\/.*\/redirection\/123123/)

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -96,7 +96,7 @@
             clique sur le bouton ci-dessous.
         </p>
         <p>
-            <strong>Attention ! </strong> En signalant ton départ, nous alons :
+            <strong>Attention !</strong> En signalant ton départ, nous allons :
             <ul>
                 <li>
                     Clôturer ton compte email

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -106,7 +106,7 @@
                 </li>
             </ul>
         </p>
-        <form onsubmit="return confirm('Es tu sur de vouloir supprimer ton compte mail et ses redirections ?');" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
+        <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections ?');" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
             <div class="form__group">
                 <button class="button no-margin" type="submit">Signaler mon départ</button>
             </div>

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -87,6 +87,34 @@
     </div>
 
 
+<% if(isExpired && emailInfos) { %>
+    <div class="panel">
+        <h3>Ta mission a terminé ?</h3>
+        <p>
+            La date de fin dans ta fiche est le <%= userInfos.end %>.
+            Si tu ne fais plus partie de la communauté Beta.gouv,
+            clique sur le bouton ci-dessous.
+        </p>
+        <p>
+            <strong>Attention ! </strong> En signalant ton départ, nous alons :
+            <ul>
+                <li>
+                    Clôturer ton compte email
+                </li>
+                <li>
+                    Supprimer toutes tes redirections
+                </li>
+            </ul>
+        </p>
+        <form onsubmit="return confirm('Es tu sur de vouloir supprimer ton compte mail et ses redirections ?');" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
+            <div class="form__group">
+                <button class="button no-margin" type="submit">Signaler mon départ</button>
+            </div>
+        </form>
+    </div>
+<% } %>
+
+
     <div class="row">
         <div class="panel panel-full-width">
             <h3>

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -1,28 +1,7 @@
 <%- include('partials/nav-header'); -%>
 
 <div class="module">
-    <% if(isExpired && (emailInfos || (user.redirections && user.redirections.length > 0))) { %>
-        <div class="panel">
-            <h3>Clotûrer ton compte</h3>
-            <p>
-                <strong>Cette action est irréversible.</strong>
-                <ul>
-                    <li>
-                        Tu ne pourras plus recevoir d'emails <strong>@beta.gouv.fr</strong>
-                    </li>
-                    <li>
-                        Tu ne pourras plus te connecter aux applications (le pad...) avec ton compte @beta.gouv.fr
-                    </li>
-                </ul>
-            </p>
-            <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections ?');" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
-                <div class="form__group">
-                    <button class="button margin-right-10" type="submit">Clotûrer mon compte</button>
-                    <a href="https://github.com/betagouv/beta.gouv.fr/blob/master/content/_authors/<%= userInfos.id %>.md" target="_blank"> Oups, non finalement </a>
-                </div>
-            </form>
-        </div>
-    <% } %>
+
     <div class="row">
         <div class="panel panel-partial-width">
             <div class="account-split-panel">
@@ -185,5 +164,27 @@
               <% } %>
         </div>
     </div>
+
+    <% if(emailInfos || (redirections && redirections.length > 0)) { %>
+        <div class="panel">
+            <h3>❗ Clôturer mon compte</h3>
+            <p>Si tu as quitté la communauté, clôture ton compte :</p>
+
+            <ul>
+                <li>
+                    Clôturer ton compte email
+                </li>
+                <li>
+                    Supprimer toutes tes redirections
+                </li>
+            </ul>
+            <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections ?');" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
+                <div class="form__group">
+                    <button class="button margin-right-10" type="submit">Clotûrer mon compte</button>
+                </div>
+            </form>
+        </div>
+    <% } %>
+
 </div>
 <%- include('partials/nav-footer'); -%>

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -1,6 +1,28 @@
 <%- include('partials/nav-header'); -%>
 
 <div class="module">
+    <% if(isExpired && (emailInfos || (user.redirections && user.redirections.length > 0))) { %>
+        <div class="panel">
+            <h3>Clotûrer ton compte</h3>
+            <p>
+                <strong>Cette action est irréversible.</strong>
+                <ul>
+                    <li>
+                        Tu ne pourras plus recevoir d'emails <strong>@beta.gouv.fr</strong>
+                    </li>
+                    <li>
+                        Tu ne pourras plus te connecter aux applications (le pad...) avec ton compte @beta.gouv.fr
+                    </li>
+                </ul>
+            </p>
+            <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections ?');" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
+                <div class="form__group">
+                    <button class="button margin-right-10" type="submit">Clotûrer mon compte</button>
+                    <a href="https://github.com/betagouv/beta.gouv.fr/blob/master/content/_authors/<%= userInfos.id %>.md" target="_blank"> Oups, non finalement </a>
+                </div>
+            </form>
+        </div>
+    <% } %>
     <div class="row">
         <div class="panel panel-partial-width">
             <div class="account-split-panel">
@@ -85,35 +107,6 @@
             <% } %>
         </div>
     </div>
-
-
-<% if(isExpired && (emailInfos || (user.redirections && user.redirections.length > 0))) { %>
-    <div class="panel">
-        <h3>Ta mission a terminé ?</h3>
-        <p>
-            La date de fin dans ta fiche est le <%= userInfos.end %>.
-            Si tu ne fais plus partie de la communauté Beta.gouv,
-            clique sur le bouton ci-dessous.
-        </p>
-        <p>
-            <strong>Attention !</strong> En signalant ton départ, nous allons :
-            <ul>
-                <li>
-                    Clôturer ton compte email
-                </li>
-                <li>
-                    Supprimer toutes tes redirections
-                </li>
-            </ul>
-        </p>
-        <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections ?');" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
-            <div class="form__group">
-                <button class="button no-margin" type="submit">Signaler mon départ</button>
-            </div>
-        </form>
-    </div>
-<% } %>
-
 
     <div class="row">
         <div class="panel panel-full-width">

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -87,7 +87,7 @@
     </div>
 
 
-<% if(isExpired && emailInfos) { %>
+<% if(isExpired && (emailInfos || (user.redirections && user.redirections.length > 0))) { %>
     <div class="panel">
         <h3>Ta mission a terminé ?</h3>
         <p>

--- a/views/member.ejs
+++ b/views/member.ejs
@@ -34,6 +34,33 @@
         <% } %>
     </div>
 
+<% if(isExpired && emailInfos) { %>
+    <div class="panel">
+        <h3>Membre parti ?</h3>
+        <p>
+            La date de fin de <%= userInfos.fullname %> est le <%= userInfos.end %>.
+            Si <%= userInfos.fullname %> ne fait plus partie de la communauté Beta.gouv,
+            clique sur le bouton ci-dessous.
+        </p>
+        <p>
+            <strong>Attention ! </strong> En signalant son départ, nous alons :
+            <ul>
+                <li>
+                    Clôturer son compte email
+                </li>
+                <li>
+                    Supprimer toutes ses redirections
+                </li>
+            </ul>
+        </p>
+        <form onsubmit="return confirm('Es tu sur de vouloir supprimer le compte mail et ses redirections pour <%= userInfos.fullname %> ?');" class="no-margin" action="/users/<%= requestedUserId %>/email/delete" method="POST">
+            <div class="form__group">
+                <button class="button no-margin" type="submit">Signaler le départ de <%= userInfos.fullname %></button>
+            </div>
+        </form>
+    </div>
+<% } %>
+
     <div class="panel">
         <% if(userInfos) { %>
             <% if(marrainageState) { %>

--- a/views/member.ejs
+++ b/views/member.ejs
@@ -1,5 +1,30 @@
 <%- include('partials/nav-header'); -%>
 <div class="module">
+
+<% if(isExpired && (emailInfos || (user.redirections && user.redirections.length > 0))) { %>
+    <div class="panel">
+        <h3>Clotûrer le compte de <%= userInfos.fullname %> ?</h3>
+
+        <p>
+            <strong>Cette action est irréversible.</strong>
+            <ul>
+                <li>
+                    <%= userInfos.fullname %> ne pourra plus recevoir d'emails <strong>@beta.gouv.fr</strong>
+                </li>
+                <li>
+                    <%= userInfos.fullname %> ne pourra plus se connecter aux applications (le pad...) avec son compte @beta.gouv.fr
+                </li>
+            </ul>
+        </p>
+        <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections pour <%= userInfos.fullname %> ?');" class="no-margin" action="/users/<%= requestedUserId %>/email/delete" method="POST">
+            <div class="form__group">
+                <button class="button margin-right-10" type="submit">Clotûrer le compte</button>
+                <a href="https://github.com/betagouv/beta.gouv.fr/blob/master/content/_authors/<%= userInfos.id %>.md" target="_blank"> Oups, non finalement </a>
+            </div>
+        </form>
+    </div>
+<% } %>
+
     <div class="panel">
         <% if(userInfos) { %>
             <div>
@@ -33,33 +58,6 @@
             <a class="button no-margin" href="https://github.com/betagouv/beta.gouv.fr/new/master/content/_authors/?filename=<%= requestedUserId %>.md" target="_blank">Créer sur Github</a>
         <% } %>
     </div>
-
-<% if(isExpired && (emailInfos || (user.redirections && user.redirections.length > 0))) { %>
-    <div class="panel">
-        <h3>Membre parti ?</h3>
-        <p>
-            La date de fin de <%= userInfos.fullname %> est le <%= userInfos.end %>.
-            Si <%= userInfos.fullname %> ne fait plus partie de la communauté Beta.gouv,
-            clique sur le bouton ci-dessous.
-        </p>
-        <p>
-            <strong>Attention ! </strong> En signalant son départ, nous allons :
-            <ul>
-                <li>
-                    Clôturer son compte email
-                </li>
-                <li>
-                    Supprimer toutes ses redirections
-                </li>
-            </ul>
-        </p>
-        <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections pour <%= userInfos.fullname %> ?');" class="no-margin" action="/users/<%= requestedUserId %>/email/delete" method="POST">
-            <div class="form__group">
-                <button class="button no-margin" type="submit">Signaler le départ de <%= userInfos.fullname %></button>
-            </div>
-        </form>
-    </div>
-<% } %>
 
     <div class="panel">
         <% if(userInfos) { %>

--- a/views/member.ejs
+++ b/views/member.ejs
@@ -43,7 +43,7 @@
             clique sur le bouton ci-dessous.
         </p>
         <p>
-            <strong>Attention ! </strong> En signalant son départ, nous alons :
+            <strong>Attention ! </strong> En signalant son départ, nous allons :
             <ul>
                 <li>
                     Clôturer son compte email
@@ -53,7 +53,7 @@
                 </li>
             </ul>
         </p>
-        <form onsubmit="return confirm('Es tu sur de vouloir supprimer le compte mail et ses redirections pour <%= userInfos.fullname %> ?');" class="no-margin" action="/users/<%= requestedUserId %>/email/delete" method="POST">
+        <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections pour <%= userInfos.fullname %> ?');" class="no-margin" action="/users/<%= requestedUserId %>/email/delete" method="POST">
             <div class="form__group">
                 <button class="button no-margin" type="submit">Signaler le départ de <%= userInfos.fullname %></button>
             </div>

--- a/views/member.ejs
+++ b/views/member.ejs
@@ -1,25 +1,25 @@
 <%- include('partials/nav-header'); -%>
 <div class="module">
 
-<% if(isExpired && (emailInfos || (user.redirections && user.redirections.length > 0))) { %>
+<% if(isExpired && (emailInfos || (redirections && redirections.length > 0))) { %>
     <div class="panel">
-        <h3>Clotûrer le compte de <%= userInfos.fullname %> ?</h3>
+        <h3>❗ Contrat de <%= userInfos.fullname %> arrivé à expiration</h3>
 
-        <p>
-            <strong>Cette action est irréversible.</strong>
-            <ul>
-                <li>
-                    <%= userInfos.fullname %> ne pourra plus recevoir d'emails <strong>@beta.gouv.fr</strong>
-                </li>
-                <li>
-                    <%= userInfos.fullname %> ne pourra plus se connecter aux applications (le pad...) avec son compte @beta.gouv.fr
-                </li>
-            </ul>
-        </p>
+        <p>Le contrat de <%= userInfos.fullname %> est arrivé à terme le <strong><%= userInfos.end %></strong>.</p>
+        <p>Si <%= userInfos.fullname %> a effectivement quitté la communauté, clôturez son compte :</p>
+
+        <ul>
+            <li>
+                Clôturer son compte email
+            </li>
+            <li>
+                Supprimer toutes ses redirections
+            </li>
+        </ul>
         <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections pour <%= userInfos.fullname %> ?');" class="no-margin" action="/users/<%= requestedUserId %>/email/delete" method="POST">
             <div class="form__group">
                 <button class="button margin-right-10" type="submit">Clotûrer le compte</button>
-                <a href="https://github.com/betagouv/beta.gouv.fr/blob/master/content/_authors/<%= userInfos.id %>.md" target="_blank"> Oups, non finalement </a>
+                <a href="https://github.com/betagouv/beta.gouv.fr/blob/master/content/_authors/<%= userInfos.id %>.md" target="_blank">Mettre à jour le contrat</a>
             </div>
         </form>
     </div>

--- a/views/member.ejs
+++ b/views/member.ejs
@@ -34,7 +34,7 @@
         <% } %>
     </div>
 
-<% if(isExpired && emailInfos) { %>
+<% if(isExpired && (emailInfos || (user.redirections && user.redirections.length > 0))) { %>
     <div class="panel">
         <h3>Membre parti ?</h3>
         <p>


### PR DESCRIPTION
Cette PR est lié à #27. Il s’agit d'un premier jet pour avoir comme base de discussion. 

Dans un premier temps, seulement le compte email ainsi que ses redirections sont supprimés (il n'y a pas encore de redirection pour _depart@beta.gouv.fr_ ni de révocation des droits d'écriture sur Github).

À noter que c'est difficile de tester dans la review app car nous utilisons le vrai repo Github pour obtenir les dates de fin.

Lorsqu'un utilisateur supprime son propre compte, il est aussi log-out du secrétariat.

Il est impossible de faire cette procédure pour quelqu'un qui n'a pas sa date de fin dans le passé.

Je suis preneur de vos retours :wink:  @raphodn @astranchet @jdauphant 

Quelques screenshots :

![image](https://user-images.githubusercontent.com/1225929/96283559-af1bf980-0fdc-11eb-9111-8a37ef1e5604.png)

![image](https://user-images.githubusercontent.com/1225929/96283583-b8a56180-0fdc-11eb-8763-fa4a91250621.png)

![image](https://user-images.githubusercontent.com/1225929/96283689-de326b00-0fdc-11eb-8da0-8407dfccd283.png)

![image](https://user-images.githubusercontent.com/1225929/96283714-e8ed0000-0fdc-11eb-840b-32d18060a618.png)

