### PR TITLE
Utilise string pour la variable MAIL_IGNORE_TLS du docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       MAIL_USER: mailpassword
       MAIL_HOST: maildev
       MAIL_PORT: 25
-      MAIL_IGNORE_TLS: true
+      MAIL_IGNORE_TLS: "true"
       SECURE: "false"
     ports:
       - "8100:8100"


### PR DESCRIPTION
Docker compose n'accepte pas des valeurs bool dans les variables d'environnement :

```
The Compose file './docker-compose.yml' is invalid because:
services.web.environment.MAIL_IGNORE_TLS contains true, which is an invalid type, it should be a string, number, or a null
```

Cette PR transforme le boolean en string dans le docker-compose.yml