### PR TITLE
Gère le caractère ë dans la création de fiches Github. 

### DIFF
--- a/controllers/utils.js
+++ b/controllers/utils.js
@@ -25,7 +25,7 @@ const requestWithAuth = request.defaults({
 function removeAccents(str) {
   const map = {
     a: 'á|à|ã|â|À|Á|Ã|Â',
-    e: 'é|è|ê|É|È|Ê',
+    e: 'é|è|ê|ë|É|È|Ê|Ë',
     i: 'í|ì|î|Í|Ì|Î',
     o: 'ó|ò|ô|õ|Ó|Ò|Ô|Õ',
     u: 'ú|ù|û|ü|Ú|Ù|Û|Ü',

--- a/tests/test-onboarding.js
+++ b/tests/test-onboarding.js
@@ -220,12 +220,12 @@ describe('Onboarding', () => {
         });
     });
 
-    it('filename should not contain accents', (done) => {
+    it('branch name should not contain accents or special characters', (done) => {
       chai.request(app)
         .post('/onboarding')
         .type('form')
         .send({
-          firstName: 'Férnàndáô',
+          firstName: 'Raphaël Férnàndáô',
           lastName: 'Úñíbe',
           role: 'Dev',
           start: '2020-01-01',
@@ -233,8 +233,8 @@ describe('Onboarding', () => {
           status: 'Independant',
         })
         .end((err, res) => {
-          const path = this.createGithubFile.args[0][0];
-          path.should.contain('fernandao.unibe.md');
+          const branch = this.createGithubBranch.args[0][1];
+          branch.should.contain('author-raphael-fernandao-unibe-');
           done();
         });
     });


### PR DESCRIPTION
Exemple de PR qui fait échouer les tests : https://github.com/betagouv/beta.gouv.fr/pull/4471

À terme il faudra envisager un moyen plus exhaustif pour remplacer les caractères spéciaux, par ex. [normalize-diacritics](https://github.com/motss/normalize-diacritics)