### PR TITLE
Fix du TypeError dans le titre de la page membre

### DIFF
--- a/controllers/communityController.js
+++ b/controllers/communityController.js
@@ -49,7 +49,7 @@ module.exports.getMember = async function (req, res) {
       .where({ username: requestedUserId });
     const marrainageState = marrainageStateResponse[0];
 
-    const title = user.userInfos.fullname;
+    const title = user.userInfos ? user.userInfos.fullname : null;
     res.render('member', {
       title,
       requestedUserId,


### PR DESCRIPTION
_userinfos_ n'est pas renseigné quand la personne n'a pas encore un fichier GH