### PR TITLE
Ne demande pas aux marrains en cours de marrainer plus de gens

### DIFF
--- a/tests/test-marrainage.js
+++ b/tests/test-marrainage.js
@@ -345,6 +345,7 @@ describe('Marrainage', () => {
         'laurent.bossavit',
         'loup.wolff',
         'thomas.guillet',
+        'utilisateur.plusieurs.missions',
       ];
       const dbEntries = [];
       for (let i = 0; i < busyOnboarders.length; i += 1) {


### PR DESCRIPTION
Suite à la [discussion sur la distribution](https://github.com/betagouv/secretariat/issues/163#issuecomment-711041293) pour le marrainage, cette PR vise à ne pas sélectionner des gens qui sont dans la table marrainage en "last_onboarder" et completed = "false". Cette PR est liée à #163.