### PR TITLE
Fix du bug avec des liens sur Linux+Thunderbird

### DIFF
--- a/views/emails/login.ejs
+++ b/views/emails/login.ejs
@@ -5,11 +5,11 @@
   Pour t'authentifier, tu dois cliquer sur le bouton ci-dessous dans l'heure qui suit la réception de ce message.
 </p>
 
-<p>
-  <a href="<%= loginUrlWithToken %>">
-    <button style="margin-bottom: 15px;background: #006be6;padding: 10px;border: none;border-radius: 3px;color: white;min-width: 280px;box-shadow: 1px 1px 2px 0px #333;cursor: pointer;">
+<p style="margin: 30px 0px;">
+  <a 
+  href="<%= loginUrlWithToken %>"
+  style="background: #006be6;padding: 10px 40px; border: none; border-radius: 3px; color: white; box-shadow: 1px 1px 2px 0px #333; cursor: pointer; text-decoration: none;">
       Me connecter
-    </button>
   </a>
 </p>
 

--- a/views/emails/marrainageRequest.ejs
+++ b/views/emails/marrainageRequest.ejs
@@ -8,17 +8,19 @@ et pourquoi pas toi ?</p>
 Par exemple, pour prendre un café virtuel avec il/elle et lui parler un peu de ce que tu fais et ce que tu aimes particulièrement chez Beta, ou lui partager quelques conseils pour s'intégrer plus facilement dans la communauté.
 </p>
 
-<a href="<%= marrainageAcceptUrl %>">
-  <button style="margin-bottom: 15px;background: green;padding: 10px;border: none;border-radius: 3px;color: white;min-width: 280px;box-shadow: 1px 1px 2px 0px #333;cursor: pointer;">
-    J'accepte
-  </button>
-</a>
-<br/>
-<a href="<%= marrainageDeclineUrl %>">
-  <button style="padding: 10px;border: none;box-shadow: 1px 1px 2px 0px #333;min-width: 280px;cursor: pointer;">
-    Désolé, je ne suis pas disponible
-  </button>
-</a>
+<p style="margin: 15px 0;">
+  <a href="<%= marrainageAcceptUrl %>"
+    style="display:inline-block;text-decoration: none; padding: 10px 60px;border: none;border-radius: 3px;color: white;box-shadow: 1px 1px 2px 0px #333;cursor: pointer;background: green;">
+      J'accepte
+  </a>
+</p>
+
+<p style="margin: 15px 0;">
+  <a href="<%= marrainageDeclineUrl %>"
+    style="display:inline-block;text-decoration: none; padding: 10px 30px;border: none;color:#333; box-shadow: 1px 1px 2px 0px #333;cursor: pointer;pointer;background: #EEE;">
+      Désolé, je ne suis pas disponible
+  </a>
+</p>
 
 <p style="color: #999;font-size: 0.85em;">
   Cet email t’as été envoyé parce que tu es considéré comme membre de la communauté et qu’un algorithme aléatoire a pensé que tu étais 


### PR DESCRIPTION
Le bug arrive quand on a un élément `<button>` à l'intérieur d'un `<a>`. Cette configuration incite Thunderbird à regarder le lien avant de l'ouvrir sur le navigateur et donc à rendre le token d'auth invalide.