### PR TITLE
Désactive les buttons submit des formulaires pour éviter plusieurs requêtes

### DIFF
--- a/tests/test-community.js
+++ b/tests/test-community.js
@@ -84,7 +84,7 @@ describe('Community', () => {
         .get('/community/utilisateur.parti')
         .set('Cookie', `token=${utils.getJWT('utilisateur.actif')}`)
         .end((err, res) => {
-          res.text.should.include('action="/users/utilisateur.parti/email" method="POST">');
+          res.text.should.include('action="/users/utilisateur.parti/email" method="POST"');
           done();
         });
     });

--- a/tests/test-home.js
+++ b/tests/test-home.js
@@ -22,7 +22,7 @@ describe('Home', () => {
       chai.request(app)
         .get('/')
         .end((err, res) => {
-          res.text.should.include('<form action="/login" method="POST">');
+          res.text.should.include('<form action="/login" method="POST"');
           res.text.should.include('<input name="username"');
           res.text.should.include('<button class="button" type="submit">');
           done();

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -63,7 +63,7 @@
                     à t'orienter au sein de la communauté.
             </p>
             <% if(!marrainageState) { %>
-                <form class="no-margin" action="/marrainage" method="POST">
+                <form class="no-margin" action="/marrainage" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                     <div class="form__group">
                         <input type="hidden" name="newcomerId" value="<%= userInfos.id %>">
                     </div>
@@ -73,12 +73,12 @@
                 Essai numéro <%= marrainageState.count %>, procédure lancé le <%= marrainageState.created_at.toLocaleDateString('fr-FR') %>, dernière mise à jour <%= marrainageState.last_updated.toLocaleDateString('fr-FR') %>.
                 <div class="form__group margin-10-0 display-flex">
                     <% if( Date.now() - marrainageState.last_updated.valueOf() > 24*3600*1000 ) { %>
-                        <form class="margin-right-10" action="/marrainage/reload" method="POST">
+                        <form class="margin-right-10" action="/marrainage/reload" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                             <input type="hidden" name="newcomerId" value="<%= userInfos.id %>">
                             <button class="button secondary no-margin" type="submit">Relancer</button>
                         </form>
                     <% } %>
-                    <form class="margin-right-10" action="/marrainage/cancel" method="POST">
+                    <form class="margin-right-10" action="/marrainage/cancel" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                         <input type="hidden" name="newcomerId" value="<%= userInfos.id %>">
                         <button class="button secondary no-margin" type="submit">Annuler</button>
                     </form>
@@ -111,7 +111,7 @@
                 <div class="redirection-item">
                     <%= redirection.to %>
                     <% if (canCreateRedirection) { %>
-                        <form class="redirection-form" action="/users/<%= userInfos.id %>/redirections/<%= redirection.to %>/delete" method="POST">
+                        <form class="redirection-form" action="/users/<%= userInfos.id %>/redirections/<%= redirection.to %>/delete" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                         <button class="redirection-remove button-outline small warning" type="submit">Supprimer</button>
                         </form>
                     <% } %>
@@ -121,7 +121,7 @@
                 <p><strong>Aucune redirections</strong></p>
             <% } %>
             <% if (canCreateRedirection) { %>
-                <form class="no-margin" action="/users/<%= userInfos.id %>/redirections" method="POST">
+                <form class="no-margin" action="/users/<%= userInfos.id %>/redirections" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                     <div class="form__group">
                         <label for="to_email">Rediriger mes mails <%= domain %> vers :</label>
                         <input name="to_email" type="email" required>
@@ -157,7 +157,7 @@
                 d'espace au début ou à la fin.
             </p>
             <% if (canChangePassword) { %>
-                <form class="no-margin" action="/users/<%= userInfos.id %>/password" method="POST">
+                <form class="no-margin" action="/users/<%= userInfos.id %>/password" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                     <input name="new_password" type="password" minlength="9" required>
                     <button class="button margin-10-0" type="submit">Changer</button>
                 </form>
@@ -178,7 +178,7 @@
                     Supprimer toutes tes redirections
                 </li>
             </ul>
-            <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections ?');" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
+            <form onsubmit="const proceed = confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections ?'); event.submitter && (event.submitter.disabled = proceed); return proceed;" class="no-margin" action="/users/<%= userInfos.id %>/email/delete" method="POST">
                 <div class="form__group">
                     <button class="button margin-right-10" type="submit">Clotûrer mon compte</button>
                 </div>

--- a/views/community.ejs
+++ b/views/community.ejs
@@ -69,8 +69,9 @@
         <script>
             const emailCreationForm = document.getElementById('email-creation')
             emailCreationForm.addEventListener('submit', (e) => {
-                const emailId = e.target.email_id.value
-                e.target.action = '/users/' + emailId + '/email'
+                const emailId = e.target.email_id.value;
+                e.target.action = '/users/' + emailId + '/email';
+                e.submitter && (e.submitter.disabled = true);
             })
         </script>
     </div>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -18,7 +18,7 @@
     <% if (messages.length) { %>
       <div class="notification"><%- messages %></div>
     <% } else { %>
-      <form action="/login<%= nextParam %>" method="POST">
+      <form action="/login<%= nextParam %>" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
         <label for="username">Adresse email :</label>
         <div class="input__group">
           <input name="username" class="width-50" placeholder="prenom.nom" pattern="[a-z0-9_-]+\.[a-z0-9_-]+" autocomplete="username">

--- a/views/member.ejs
+++ b/views/member.ejs
@@ -12,7 +12,7 @@
                 <li>Clôturer son compte email</li>
                 <li>Supprimer toutes ses redirections</li>
             </ul>
-            <form onsubmit="return confirm('Es-tu sûr de vouloir supprimer ton compte email et ses redirections pour <%= userInfos.fullname %> ?');" class="no-margin" action="/users/<%= username %>/email/delete" method="POST">
+            <form onsubmit="const proceed = confirm('Es-tu sûr de vouloir supprimer son compte email et ses redirections pour <%= userInfos.fullname %> ?'); event.submitter && (event.submitter.disabled = proceed); return proceed;" class="no-margin" action="/users/<%= username %>/email/delete" method="POST">
                 <div class="form__group">
                     <button class="button margin-right-10" type="submit">Clotûrer le compte</button>
                     <a href="https://github.com/betagouv/beta.gouv.fr/blob/master/content/_authors/<%= userInfos.id %>.md" target="_blank">Mettre à jour le contrat</a>
@@ -69,12 +69,12 @@
                         </p>
                         <div class="form__group margin-10-0 display-flex">
                             <% if( Date.now() - marrainageState.last_updated.valueOf() > 24*3600*1000 ) { %>
-                                <form class="margin-right-10" action="/marrainage/reload" method="POST">
+                                <form class="margin-right-10" action="/marrainage/reload" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                                     <input type="hidden" name="newcomerId" value="<%= userInfos.id %>">
                                     <button class="button secondary no-margin" type="submit">Relancer</button>
                                 </form>
                             <% } %>
-                            <form class="margin-right-10" action="/marrainage/cancel" method="POST">
+                            <form class="margin-right-10" action="/marrainage/cancel" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                                 <input type="hidden" name="newcomerId" value="<%= userInfos.id %>">
                                 <button class="button secondary no-margin" type="submit">Annuler</button>
                             </form>
@@ -86,7 +86,7 @@
                         <%= userInfos.fullname %> vient d'arriver dans la communauté ? Tu peux inviter quelqu'un à devenir son ou sa marrain·e.
                         Cela lui permettra de rencontrer des membres de la communauté en dehors de son équipe.
                     </p>
-                    <form class="no-margin" action="/marrainage" method="POST">
+                    <form class="no-margin" action="/marrainage" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                         <div class="form__group  margin-10-0">
                             <input type="hidden" name="newcomerId" value="<%= userInfos.id %>">
                         </div>
@@ -109,7 +109,7 @@
         <% } else { %>
             <% if (canCreateEmail) { %>
                 <p>Tu peux créer un compte mail pour <%= userInfos.fullname %>.</p>
-                <form class="no-margin" action="/users/<%= username %>/email" method="POST">
+                <form class="no-margin" action="/users/<%= username %>/email" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                     <div class="form__group  margin-10-0">
                         <label>
                             <span class="text-color-almost-black">Email personnel ou professionnel</span><br />

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -26,7 +26,7 @@
 
         <div class="beta-banner"></div>
 
-        <form action="/onboarding" method="POST">
+        <form action="/onboarding" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
             <h4>Tes infos persos</h4>
 
             <div class="form__group">


### PR DESCRIPTION
Cette PR prend l'approche de désactiver les buttons des formulaires POST pour éviter que la requête soit traitée plusieurs fois. À noter que certains navigateurs (notamment IE) ne supportent pas le `event.submitter`, donc cette fonctionnalité ne sera pas activée pour eux.

On pourrait refactorer ça pour avoir une fonction JS à la racine avec le code répété `event.submitter && (event.submitter.disabled = true);` mais ça pourrait être un peu moins lisible. À discuter :thinking:  