### PR TITLE
Supprime le bouton revenir à l'accueil de la confirmation de création de compte

### DIFF
--- a/views/onboardingSuccess.ejs
+++ b/views/onboardingSuccess.ejs
@@ -10,6 +10,5 @@
         <p>Une fois la fiche validée, tout membre de la communauté sera en mesure de te créer un adresse email <em>@beta.gouv.fr</em>.</p>
         <p>À bientôt !</p>
 
-        <a class="button" href="/">Revenir à l'accueil</a>
     </div>
 </div>


### PR DESCRIPTION
Je propose de supprimer le bouton, il n'a pas d'intéret :
![image](https://user-images.githubusercontent.com/1238254/101535899-935c2080-3999-11eb-83a3-d5f0dfe53a10.png)
Après 
![image](https://user-images.githubusercontent.com/1238254/101535927-9e16b580-3999-11eb-92c1-f7b90841b6e9.png)

On ne veut pas déclencher l'action de retourner à l'accueil pour l'utilisateur (on pourra réfléchir à l'UX de ce que l'on veut lui faire faire par la suite).
Et revenir à l'accueil est plus pertubant qu'autre chose, ça n'a pas d'intérêt pour l'utilisateur.