### PR TITLE
Fix de l'URL mal formé après onboarding 

### DIFF
--- a/controllers/onboardingController.js
+++ b/controllers/onboardingController.js
@@ -180,7 +180,7 @@ module.exports.postForm = async function (req, res) {
       const referentEmailInfos = await BetaGouv.emailInfos(referent);
       if (referentEmailInfos && referentEmailInfos.email) {
         const prUrl = prInfo.data.html_url;
-        const memberUrl = `${config.protocol}://${config.host}/community/${username}}`;
+        const memberUrl = `${config.protocol}://${config.host}/community/${username}`;
         const html = await ejs.renderFile('./views/emails/onboardingReferent.ejs', {
           referent, prUrl, name, memberUrl,
         });


### PR DESCRIPTION
Il y a deux parts à ce bug :
1- Un `}` redondant à la fin de l'URL (cette PR), et
2- La variable d'environnement `HOSTNAME` manquante dans l'app staging (déjà réglé)