### PR TITLE
Lancer la création d'email toutes les minutes

### DIFF
--- a/schedulers/emailCreationScheduler.js
+++ b/schedulers/emailCreationScheduler.js
@@ -33,7 +33,7 @@ module.exports.createEmailAddresses = async function () {
 };
 
 module.exports.emailCreationJob = new CronJob(
-  '0 * * * * *', // every four minutes
+  '0 * * * * *', // every minute at second 0
   module.exports.createEmailAddresses,
   null,
   true,

--- a/schedulers/emailCreationScheduler.js
+++ b/schedulers/emailCreationScheduler.js
@@ -33,7 +33,7 @@ module.exports.createEmailAddresses = async function () {
 };
 
 module.exports.emailCreationJob = new CronJob(
-  '* */4 * * * *', // every four minutes
+  '0 * * * * *', // every four minutes
   module.exports.createEmailAddresses,
   null,
   true,


### PR DESCRIPTION
Je lance toutes les minutes et j'ai mis "0" sur les secondes pour éviter le bug de la dernière fois, je pense, j'ai l'impression que ça aurait fait 60 secondes toutes les 4 minutes.

Je ne pense pas qu'il y ai de soucis à mettre 1 minute, on fait un seul appel réseau et une query en DB.