### PR TITLE
Revert commit du catch sur le cron creation email

### DIFF
--- a/schedulers/emailCreationScheduler.js
+++ b/schedulers/emailCreationScheduler.js
@@ -5,36 +5,31 @@ const BetaGouv = require('../betagouv');
 const { createEmail } = require('../controllers/usersController');
 
 module.exports.createEmailAddresses = async function () {
-  try {
-    console.log('Demarrage du cron job pour la création des adresses email');
+  console.log('Demarrage du cron job pour la création des adresses email');
 
-    const dbUsers = await knex('users').whereNotNull('secondary_email');
-    const githubUsers = await BetaGouv.usersInfos();
+  const dbUsers = await knex('users').whereNotNull('secondary_email');
+  const githubUsers = await BetaGouv.usersInfos();
 
-    const concernedUsers = githubUsers.reduce((acc, user) => {
-      const dbUser = dbUsers.find((x) => x.username === user.id);
-      if (dbUser) {
-        acc.push({ ...user, ...{ toEmail: dbUser.secondary_email } });
-      }
-      return acc;
-    }, []);
-
-    const emailCreationTasks = [];
-
-    /* https://eslint.org/docs/rules/no-await-in-loop#when-not-to-use-it */
-    /* eslint-disable no-await-in-loop */
-    for (let i = 0; i < concernedUsers.length; i += 1) {
-      const emailInfos = await BetaGouv.emailInfos(concernedUsers[i].id);
-      if (!emailInfos || !emailInfos.email) {
-        emailCreationTasks.push(createEmail(concernedUsers[i].id, 'Secretariat Cron', concernedUsers[i].toEmail));
-      }
+  const concernedUsers = githubUsers.reduce((acc, user) => {
+    const dbUser = dbUsers.find((x) => x.username === user.id);
+    if (dbUser) {
+      acc.push({ ...user, ...{ toEmail: dbUser.secondary_email } });
     }
+    return acc;
+  }, []);
 
-    return await Promise.all(emailCreationTasks);
-  } catch (err) {
-    console.error(err);
-    return Promise.resolve();
+  const emailCreationTasks = [];
+
+  /* https://eslint.org/docs/rules/no-await-in-loop#when-not-to-use-it */
+  /* eslint-disable no-await-in-loop */
+  for (let i = 0; i < concernedUsers.length; i += 1) {
+    const emailInfos = await BetaGouv.emailInfos(concernedUsers[i].id);
+    if (!emailInfos || !emailInfos.email) {
+      emailCreationTasks.push(createEmail(concernedUsers[i].id, 'Secretariat Cron', concernedUsers[i].toEmail));
+    }
   }
+
+  return Promise.all(emailCreationTasks);
 };
 
 module.exports.emailCreationJob = new CronJob(

--- a/tests/test-user.js
+++ b/tests/test-user.js
@@ -1,16 +1,12 @@
 const chai = require('chai');
 const nock = require('nock');
 const sinon = require('sinon');
-
 const config = require('../config');
 const app = require('../index');
 const utils = require('./utils.js');
 const knex = require('../db');
 const controllerUtils = require('../controllers/utils');
 const { createEmailAddresses } = require('../schedulers/emailCreationScheduler');
-const { expect } = require('chai');
-
-const should = chai.should();
 
 describe('User', () => {
   describe('POST /users/:username/email unauthenticated', () => {
@@ -575,75 +571,6 @@ describe('User', () => {
       });
     });
 
-    it('should log error when GET OVH returns 500 error', (done) => {
-      utils.cleanMocks();
-      utils.mockUsers();
-      utils.mockSlack();
-      utils.mockOvhTime();
-
-      const consoleSpy = sinon.spy(console, 'error');
-
-      const getOvhEmailCreation = nock(/.*ovh.com/)
-        .get(/^.*email\/domain\/.*\/account\/.*/)
-        .reply(500);
-
-      const postOvhEmailCreation = nock(/.*ovh.com/)
-        .post(/^.*email\/domain\/.*\/account/)
-        .reply(200);
-
-      knex('users').insert({
-        username: 'utilisateur.nouveau',
-        secondary_email: 'utilisateur.nouveau.perso@example.com',
-      }).then(async () => {
-        const cronOutcome = await createEmailAddresses();
-        getOvhEmailCreation.isDone().should.be.true;
-        postOvhEmailCreation.isDone().should.be.false;
-        should.not.exist(cronOutcome);
-        console.error.called.should.be.true;
-        expect(consoleSpy.firstCall.args[0].message).to.be.equal(`OVH Error GET on /email/domain/${config.domain}/account/utilisateur.nouveau : {"error":500,"message":null}`)
-        done();
-      })
-      .catch(done)
-      .finally(() => {
-        console.error.restore();
-      });
-    });
-
-    it('should log error when POST OVH returns 500 error', (done) => {
-      utils.cleanMocks();
-      utils.mockUsers();
-      utils.mockSlack();
-      utils.mockOvhTime();
-
-      const consoleSpy = sinon.spy(console, 'error');
-
-      const getOvhEmailCreation = nock(/.*ovh.com/)
-        .get(/^.*email\/domain\/.*\/account\/.*/)
-        .reply(200);
-
-      const ovhEmailCreation = nock(/.*ovh.com/)
-        .post(/^.*email\/domain\/.*\/account/)
-        .reply(500);
-
-      knex('users').insert({
-        username: 'utilisateur.nouveau',
-        secondary_email: 'utilisateur.nouveau.perso@example.com',
-      })
-      .then(async () => {
-        const cronOutcome = await createEmailAddresses();
-        getOvhEmailCreation.isDone().should.be.true;
-        ovhEmailCreation.isDone().should.be.true;
-        should.not.exist(cronOutcome);
-        console.error.called.should.be.true;
-        expect(consoleSpy.firstCall.args[0].message).to.be.equal(`OVH Error POST on /email/domain/${config.domain}/account : {"error":500,"message":null}`)
-        done();
-      })
-      .catch(done)
-      .finally(() => {
-        console.error.restore();
-      });
-    });
-
     it('should not create email accounts if already created', (done) => {
       // For this case we need to reset the basic nocks in order to return
       // a different response to indicate that newcomer.test has an
@@ -669,15 +596,11 @@ describe('User', () => {
       knex('users').insert({
         username: 'utilisateur.nouveau',
         secondary_email: 'utilisateur.nouveau.perso@example.com',
-      })
-      .then(async () => {
+      }).then(async () => {
         await createEmailAddresses();
         ovhEmailCreation.isDone().should.be.false;
         this.sendEmailStub.notCalled.should.be.true;
         done();
-      })
-      .finally(() => {
-        console.error.restore();
       });
     });
 


### PR DESCRIPTION
Mise en commentaire du catch et des tests correspondant pour revenir à l'état initial, pour laisser Scalingo recevoir les erreurs, le temps de mettre en place Sentry ou autre solution de monitoring.