### PR TITLE
Changement du timeout par default à 3000ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "makeMigration": "knex migrate:make",
     "dev": "nodemon --icu-data-dir=./node_modules/full-icu index.js",
     "lint": "eslint . --fix",
-    "test": "mocha --icu-data-dir=./node_modules/full-icu tests/*.js --exit --require ./tests/env-setup.js"
+    "test": "mocha --icu-data-dir=./node_modules/full-icu tests/*.js --exit --require ./tests/env-setup.js --timeout 3000"
   },
   "husky": {
     "hooks": {

--- a/tests/test-account.js
+++ b/tests/test-account.js
@@ -26,6 +26,8 @@ describe('Account', () => {
   });
 
   describe('GET /account authenticated', () => {
+    // first render of template 'account' can be slow and exceed timeout this test may fail if timeout < 2000
+
     it('should return a valid page', (done) => {
       chai.request(app)
         .get('/account')


### PR DESCRIPTION
Le test sur la page account fail parfois en local lors de la première request, il semble que l'initialisation du template `account` la première fois soit parfois un peu longue, mais ça ne semble pas relever d'un problème de performance dans le code.

- timeout par default mis à 3000
- ajout d'un commentaire dans le test en question
