### PR TITLE
Fix/394: onboarding form - regexp on GitHub username

### DIFF
--- a/controllers/onboardingController.js
+++ b/controllers/onboardingController.js
@@ -4,6 +4,7 @@ const config = require('../config');
 const utils = require('./utils');
 const BetaGouv = require('../betagouv');
 const knex = require('../db');
+const { isValidGithubUserName } = require('../lib/github');
 
 function createBranchName(username) {
   const refRegex = /( |\.|\\|~|^|:|\?|\*|\[)/gm;
@@ -108,7 +109,7 @@ module.exports.postForm = async function (req, res) {
     }
 
     function shouldBeOnlyUsername(field, value) {
-      if (!value || (!value.startsWith('http') && !value.startsWith('https') && !value.includes('/'))) {
+      if (isValidGithubUserName(value)) {
         return value;
       }
       formValidationErrors.push(`${field} : la valeur doit être le nom du membre seul et ne doit pas être l'URL du membre`);

--- a/controllers/onboardingController.js
+++ b/controllers/onboardingController.js
@@ -112,7 +112,7 @@ module.exports.postForm = async function (req, res) {
       if (isValidGithubUserName(value)) {
         return value;
       }
-      formValidationErrors.push(`${field} : la valeur doit être le nom du membre seul et ne doit pas être l'URL du membre`);
+      formValidationErrors.push(`${field} : la valeur doit être le nom du membre seul et ne doit pas être l'URL du membre ni commencer avec "@"`);
       return null;
     }
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -88,3 +88,8 @@ async function fetchDetails(input) {
 }
 
 exports.fetchDetails = fetchDetails;
+
+function isValidGithubUserName(value) {
+  return !value || (!value.startsWith('http') && !value.startsWith('https') && !value.includes('/') && !value.includes('@'));
+}
+exports.isValidGithubUserName = isValidGithubUserName;

--- a/lib/github.js
+++ b/lib/github.js
@@ -89,7 +89,12 @@ async function fetchDetails(input) {
 
 exports.fetchDetails = fetchDetails;
 
+/**
+ * Username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.
+ * @see https://github.com/shinnn/github-username-regex
+ * @see https://github.com/join
+ */
 function isValidGithubUserName(value) {
-  return !value || (!value.startsWith('http') && !value.startsWith('https') && !value.includes('/') && !value.includes('@'));
+  return !value || (/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(value));
 }
 exports.isValidGithubUserName = isValidGithubUserName;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2700,9 +2700,9 @@
       "dev": true
     },
     "husky": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.7.tgz",
-      "integrity": "sha512-0fQlcCDq/xypoyYSJvEuzbDPHFf8ZF9IXKJxlrnvxABTSzK1VPT2RKYQKrcgJ+YD39swgoB6sbzywUqFxUiqjw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
+      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
-    "husky": "^4.3.7",
+    "husky": "^4.3.8",
     "lint-staged": "^10.5.3",
     "mocha": "^8.2.1",
     "nock": "^13.0.5",

--- a/tests/test-lib-github.js
+++ b/tests/test-lib-github.js
@@ -1,0 +1,21 @@
+const chai = require('chai');
+
+const { isValidGithubUserName } = require('../lib/github');
+
+describe('Github lib', () => {
+  describe('isValidGithubUserName', () => {
+    describe('github validation functions', () => {
+      it('should return false if github input contains http', () => {
+        isValidGithubUserName('https://github.com/username').should.be.false;
+      });
+
+      it('should return false if github input contains a @', () => {
+        isValidGithubUserName('@username').should.be.false;
+      });
+
+      it('should return false if github input contains a @', () => {
+        isValidGithubUserName('username').should.be.true;
+      });
+    });
+  });
+});

--- a/tests/test-lib-github.js
+++ b/tests/test-lib-github.js
@@ -16,6 +16,7 @@ describe('Github lib', () => {
       it('should return false if github input starts or ends with a hyphen ', () => {
         isValidGithubUserName('-username').should.be.false;
         isValidGithubUserName('username-').should.be.false;
+        isValidGithubUserName('user-name').should.be.true;
       });
 
       it('should return true if username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen', () => {

--- a/tests/test-lib-github.js
+++ b/tests/test-lib-github.js
@@ -5,7 +5,7 @@ const { isValidGithubUserName } = require('../lib/github');
 describe('Github lib', () => {
   describe('isValidGithubUserName', () => {
     describe('github validation functions', () => {
-      it('should return false if github input contains http', () => {
+      it('should return false if github input is a URL', () => {
         isValidGithubUserName('https://github.com/username').should.be.false;
       });
 
@@ -13,7 +13,12 @@ describe('Github lib', () => {
         isValidGithubUserName('@username').should.be.false;
       });
 
-      it('should return false if github input contains a @', () => {
+      it('should return false if github input starts or ends with a hyphen ', () => {
+        isValidGithubUserName('-username').should.be.false;
+        isValidGithubUserName('username-').should.be.false;
+      });
+
+      it('should return true if username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen', () => {
         isValidGithubUserName('username').should.be.true;
       });
     });

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -63,10 +63,13 @@
 
             <div class="form__group">
                 <label for="github">
-                    <span>Utilisateur Github</span><br />
+                    <span>Nom d'utilisateur Github</span><br />
                     Si tu as un compte, tu peux être ajouté à l'organisation Github BetaGouv.
                 </label>
-                <input name="github" pattern="^(?!http://|https://).+" value="<%= formData.github %>" title="Pas d'url, juste ton nom d'utilisateur Github">
+                <input name="github" pattern="^(?!http://|https://).+"
+                    value="<%= formData.github %>"
+                    title="Pas d'url, juste ton nom d'utilisateur Github sans l'@"
+                    placeholder="Pas d'url, juste ton nom d'utilisateur Github sans l'@">
             </div>
 
 

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -63,7 +63,7 @@
 
             <div class="form__group">
                 <label for="github">
-                    <span>Nom d'utilisateur Github</span><br />
+                    <span>Nom d'utilisateur Github - sans l'@ et sans l'URL</span><br />
                     Si tu as un compte, tu peux être ajouté à l'organisation Github BetaGouv.
                 </label>
                 <input name="github" pattern="^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$"

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -66,7 +66,7 @@
                     <span>Nom d'utilisateur Github</span><br />
                     Si tu as un compte, tu peux être ajouté à l'organisation Github BetaGouv.
                 </label>
-                <input name="github" pattern="^(?!http://|https://).+"
+                <input name="github" pattern="^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$"
                     value="<%= formData.github %>"
                     title="Pas d'url, juste ton nom d'utilisateur Github sans l'@"
                     placeholder="Pas d'url, juste ton nom d'utilisateur Github sans l'@">


### PR DESCRIPTION
# But
Améliorer le formulaire pour l'embarquement en refusant les nom d'utilisateur github non valide avec la règle de github sur les noms d'utilisateur
> Username may only contain alphanumeric characters or single hyphens, and cannot begin or end with a hyphen.

Léger refactoring pour permettre de tester la fonction en charge des noms d'utilisateur github

Issue liée : https://github.com/betagouv/secretariat/issues/394

## Demo
Sur le formulaire onboarding :
![image](https://user-images.githubusercontent.com/4059615/105154889-49269d00-5b0a-11eb-8e77-64e20bcfab50.png)

Erreur lié à la regexp github
![image](https://user-images.githubusercontent.com/4059615/105157814-a40dc380-5b0d-11eb-8ede-02b37d9ff3af.png)

## Liens
 *  https://github.com/shinnn/github-username-regex
 *  https://github.com/join