### PR TITLE
Ajout de la fonctionnalité de réinitialisation de mot de passe oublié

### DIFF
--- a/controllers/passwordResetController.js
+++ b/controllers/passwordResetController.js
@@ -1,0 +1,123 @@
+const crypto = require('crypto');
+const ejs = require('ejs');
+const knex = require('../db');
+const config = require('../config');
+const BetaGouv = require('../betagouv');
+const utils = require('./utils');
+const { updatePassword } = require('./usersController');
+
+module.exports.getPasswordReset = async function (req, res) {
+  res.render('passwordReset', {
+    errors: req.flash('error'),
+    messages: req.flash('message'),
+    domain: config.domain,
+  });
+};
+
+module.exports.postPasswordReset = async function (req, res) {
+  try {
+    const { email } = req.body;
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!email || !emailRegex.test(email)) {
+      throw new Error("L'adresse email renseignée n'est pas valide");
+    }
+    const dbResponse = await knex('users').where({ secondary_email: email });
+    if (!dbResponse || dbResponse.length === 0) {
+      throw new Error("Nous n'avons pas trouvé un utilisateur avec cette adresse email.");
+    }
+
+    const dbUser = dbResponse[0];
+
+    const emailInfos = await BetaGouv.emailInfos(dbUser.username);
+    if (!emailInfos || !emailInfos.email) {
+      throw new Error(`Le compte spécifié n'a pas d'adresse email ${config.domain}`);
+    }
+
+    const token = crypto.randomBytes(256).toString('base64');
+    const expirationDate = new Date();
+    expirationDate.setHours(expirationDate.getHours() + 1);
+
+    await knex('password_reset_tokens').insert({
+      token,
+      username: dbUser.username,
+      email: emailInfos.email,
+      expires_at: expirationDate,
+    });
+
+    const passwordResetUrlWithToken = `${config.protocol}://${config.host}/passwordReset/form?passwordResetToken=${encodeURIComponent(token)}`;
+    const html = await ejs.renderFile('./views/emails/passwordReset.ejs', { passwordResetUrlWithToken });
+
+    await utils.sendMail(dbUser.secondary_email, 'Réinitialisation de mot de passe', html);
+    res.redirect('/passwordReset/emailSent');
+  } catch (error) {
+    console.error(error);
+    req.flash('error', error.message);
+    res.redirect('/passwordReset');
+  }
+};
+
+module.exports.getEmailSent = async function (req, res) {
+  res.render('passwordResetEmailSent', {});
+};
+
+module.exports.getForm = async function (req, res) {
+  try {
+    if (!req.query || !req.query.passwordResetToken) {
+      throw new Error('Token de réinitialisation manquant');
+    }
+
+    const tokenDbResponse = await knex('password_reset_tokens').select()
+      .where({ token: req.query.passwordResetToken })
+      .andWhere('expires_at', '>', new Date());
+
+    if (tokenDbResponse.length !== 1) {
+      throw new Error('Ce lien de réinitialisation a expiré.');
+    }
+
+    res.render('passwordResetForm', {
+      token: req.query.passwordResetToken,
+      errors: req.flash('error'),
+      messages: req.flash('message'),
+    });
+  } catch (error) {
+    console.error(error);
+    req.flash('error', error.message);
+    res.redirect('/passwordReset');
+  }
+};
+
+module.exports.postForm = async function (req, res) {
+  const { password1, password2, token } = req.body;
+
+  try {
+    if (password1 !== password2) {
+      throw new Error('Les mots de passe ne correspondent pas.');
+    }
+
+    if (!token) {
+      throw new Error('Token de réinitialisation manquant.');
+    }
+
+    const tokenDbResponse = await knex('password_reset_tokens').select()
+      .where({ token })
+      .andWhere('expires_at', '>', new Date());
+
+    if (tokenDbResponse.length !== 1) {
+      throw new Error('Ce lien de réinitialisation a expiré.');
+    }
+
+    const dbToken = tokenDbResponse[0];
+    await knex('password_reset_tokens')
+      .where({ email: dbToken.email })
+      .del();
+
+    await updatePassword(dbToken.username, true, password1, dbToken.username);
+
+    req.flash('message', 'Le mot de passe a bien été modifié.');
+    res.redirect('/login');
+  } catch (error) {
+    console.error(error);
+    req.flash('error', error.message);
+    res.redirect(`/passwordReset/form?passwordResetToken=${encodeURIComponent(token)}`);
+  }
+};

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const accountController = require('./controllers/accountController');
 const communityController = require('./controllers/communityController');
 const adminController = require('./controllers/adminController');
 const onboardingController = require('./controllers/onboardingController');
+const passwordResetController = require('./controllers/passwordResetController');
 
 const app = express();
 
@@ -83,6 +84,9 @@ app.use(
       '/notifications/github',
       '/onboarding',
       /onboardingSuccess\/*/,
+      '/passwordReset',
+      '/passwordReset/emailSent',
+      '/passwordReset/form',
     ],
   }),
 );
@@ -133,5 +137,11 @@ app.get('/admin', adminController.getEmailLists);
 app.get('/onboarding', onboardingController.getForm);
 app.post('/onboarding', onboardingController.postForm);
 app.get('/onboardingSuccess/:prNumber', onboardingController.getConfirmation);
+
+app.get('/passwordReset', passwordResetController.getPasswordReset);
+app.post('/passwordReset', passwordResetController.postPasswordReset);
+app.get('/passwordReset/emailSent', passwordResetController.getEmailSent);
+app.get('/passwordReset/form', passwordResetController.getForm);
+app.post('/passwordReset/form', passwordResetController.postForm);
 
 module.exports = app.listen(config.port, () => console.log(`Running on port: ${config.port}`));

--- a/migrations/20210128111143_password-change.js
+++ b/migrations/20210128111143_password-change.js
@@ -1,0 +1,15 @@
+exports.up = function (knex) {
+  return knex.schema
+    .createTable('password_reset_tokens', (table) => {
+      table.text('token').primary();
+      table.text('username').notNullable();
+      table.text('email').notNullable();
+      table.datetime('created_at').notNullable().defaultTo(knex.fn.now());
+      table.datetime('expires_at').notNullable();
+    });
+};
+
+exports.down = function (knex) {
+  return knex.schema
+    .dropTable('password_reset_tokens');
+};

--- a/tests/test-password-reset.js
+++ b/tests/test-password-reset.js
@@ -1,0 +1,249 @@
+const nock = require('nock');
+const chai = require('chai');
+const sinon = require('sinon');
+const app = require('../index');
+const knex = require('../db');
+const controllerUtils = require('../controllers/utils');
+
+describe('Password Reset', () => {
+  beforeEach((done) => {
+    this.sendEmailStub = sinon.stub(controllerUtils, 'sendMail').returns(true);
+    this.ovhPasswordNock = nock(/.*ovh.com/)
+      .post(/^.*email\/domain\/.*\/account\/.*\/changePassword/)
+      .reply(200);
+    done();
+  });
+
+  afterEach((done) => {
+    knex('users').truncate()
+      .then(() => knex('password_reset_tokens').truncate())
+      .then(() => this.sendEmailStub.restore())
+      .then(() => done());
+  });
+
+  it('GET /passwordReset contains form', (done) => {
+    chai.request(app)
+      .get('/passwordReset')
+      .end((err, res) => {
+        res.text.should.include('<form action="/passwordReset"');
+        done();
+      });
+  });
+
+  it('POST /passwordReset redirects to email sent view', (done) => {
+    nock.cleanAll();
+    nock(/.*ovh.com/)
+        .get(/^.*email\/domain\/.*\/account\/.*/)
+        .reply(200, { email: 'membre.actif.pro@example.com' })
+        .persist();
+    const user = {
+      username: 'membre.actif',
+      secondary_email: 'membre.actif@example.com',
+    };
+    knex('users').insert(user)
+    .then(() => {
+      chai.request(app)
+        .post('/passwordReset')
+        .type('form')
+        .send({ email: 'membre.actif@example.com' })
+        .redirects(0)
+        .end((err, res) => {
+          res.should.have.status(302);
+          res.headers.location.should.equal('/passwordReset/emailSent');
+          done();
+        });
+    })
+    .catch(done);
+  });
+
+  it('POST /passwordReset with valid user sends email', (done) => {
+    nock.cleanAll();
+    nock(/.*ovh.com/)
+        .get(/^.*email\/domain\/.*\/account\/.*/)
+        .reply(200, { email: 'membre.actif.pro@example.com' })
+        .persist();
+
+    const user = {
+      username: 'membre.actif',
+      secondary_email: 'membre.actif@example.com',
+    };
+    knex('users').insert(user)
+    .then(() => {
+      chai.request(app)
+        .post('/passwordReset')
+        .type('form')
+        .send({ email: 'membre.actif@example.com' })
+        .end((err, res) => {
+          this.sendEmailStub.calledOnce.should.be.true;
+          done();
+        });
+    })
+    .catch(done);
+  });
+
+  it('POST /passwordReset with non-existent user does not send email', (done) => {
+    chai.request(app)
+      .post('/passwordReset')
+      .type('form')
+      .send({ email: 'utilisateur.qui.n.existe.pas@example.com' })
+      .end((err, res) => {
+        this.sendEmailStub.called.should.be.false;
+        done();
+      });
+  });
+
+  it('Expired tokens are not taken into account', (done) => {
+    const passwordResetToken = {
+      token: 'token',
+      username: 'membre.actif',
+      email: 'membre.actif.pro@example.com',
+      expires_at: new Date(),
+    };
+
+    knex('password_reset_tokens').insert(passwordResetToken)
+    .then(() => {
+      chai.request(app)
+      .post('/passwordReset/form')
+      .type('form')
+      .send({
+        password1: 'passwordTest',
+        password2: 'passwordTest',
+        token: 'token',
+      })
+      .redirects(0)
+      .end((err, res) => {
+        this.ovhPasswordNock.isDone().should.be.false;
+        res.should.have.status(302);
+        res.headers.location.should.includes('/passwordReset/form');
+        done();
+      });
+    })
+    .catch(done);
+  });
+
+  it('GET /passwordReset/form without token redirects to passwordReset', (done) => {
+    chai.request(app)
+      .get('/passwordReset/form')
+      .redirects(0)
+      .end((err, res) => {
+        res.should.have.status(302);
+        res.headers.location.should.equal('/passwordReset');
+        done();
+      });
+  });
+
+  it('GET /passwordReset/form with invalid token redirects to passwordReset', (done) => {
+    chai.request(app)
+      .get('/passwordReset/form?passwordResetToken=invalid_token')
+      .redirects(0)
+      .end((err, res) => {
+        res.should.have.status(302);
+        res.headers.location.should.equal('/passwordReset');
+        done();
+      });
+  });
+
+  it('GET /passwordReset/form with valid token contains a form', (done) => {
+    const expirationDate = new Date();
+    expirationDate.setHours(expirationDate.getHours() + 1);
+
+    const passwordResetToken = {
+      token: 'token',
+      username: 'membre.actif',
+      email: 'membre.actif.pro@example.com',
+      expires_at: expirationDate,
+    };
+    knex('password_reset_tokens').insert(passwordResetToken)
+    .then(() => {
+      chai.request(app)
+      .get('/passwordReset/form?passwordResetToken=token')
+      .end((err, res) => {
+        res.text.should.include('<form action="/passwordReset/form"');
+        done();
+      });
+    })
+    .catch(done);
+  });
+
+  it('POST /passwordReset/form with valid token calls OVH', (done) => {
+    const expirationDate = new Date();
+    expirationDate.setHours(expirationDate.getHours() + 1);
+
+    const passwordResetToken = {
+      token: 'token',
+      username: 'membre.actif',
+      email: 'membre.actif.pro@example.com',
+      expires_at: expirationDate,
+    };
+
+    knex('password_reset_tokens').insert(passwordResetToken)
+    .then(() => {
+      chai.request(app)
+      .post('/passwordReset/form')
+      .type('form')
+      .send({
+        password1: 'passwordTest',
+        password2: 'passwordTest',
+        token: 'token',
+      })
+      .redirects(0)
+      .end((err, res) => {
+        this.ovhPasswordNock.isDone().should.be.true;
+        res.should.have.status(302);
+        res.headers.location.should.equal('/login');
+        done();
+      });
+    })
+    .catch(done);
+  });
+
+  it('POST /passwordReset/form with invalid token does not call OVH', (done) => {
+    chai.request(app)
+      .post('/passwordReset/form')
+      .type('form')
+      .send({
+        password1: 'passwordTest',
+        password2: 'passwordTest',
+        token: 'invalid_token',
+      })
+      .redirects(0)
+      .end((err, res) => {
+        this.ovhPasswordNock.isDone().should.be.false;
+        res.should.have.status(302);
+        res.headers.location.should.include('/passwordReset/form');
+        done();
+      });
+  });
+
+  it('POST /passwordReset/form with missmatching passwords does not call OVH', (done) => {
+    const expirationDate = new Date();
+    expirationDate.setHours(expirationDate.getHours() + 1);
+
+    const passwordResetToken = {
+      token: 'token',
+      username: 'membre.actif',
+      email: 'membre.actif.pro@example.com',
+      expires_at: expirationDate,
+    };
+
+    knex('password_reset_tokens').insert(passwordResetToken)
+    .then(() => {
+      chai.request(app)
+      .post('/passwordReset/form')
+      .type('form')
+      .send({
+        password1: 'passwordTest1',
+        password2: 'passwordTest2',
+        token: 'token',
+      })
+      .redirects(0)
+      .end((err, res) => {
+        this.ovhPasswordNock.isDone().should.be.false;
+        res.should.have.status(302);
+        res.headers.location.should.includes('/passwordReset/form');
+        done();
+      });
+    })
+    .catch(done);
+  });
+});

--- a/views/emails/passwordReset.ejs
+++ b/views/emails/passwordReset.ejs
@@ -1,0 +1,22 @@
+<p>Hello ! 👋</p>
+
+<p>
+  Tu as demandé à réinitialiser ton mot de passe.
+</p>
+<p>
+  Pour ce faire, tu dois cliquer sur le bouton ci-dessous dans l'heure qui suit la réception de ce message.
+</p>
+
+<p style="margin: 30px 0px;">
+  <a 
+  href="<%= passwordResetUrlWithToken %>"
+  style="background: #006be6;padding: 10px 40px; border: none; border-radius: 3px; color: white; box-shadow: 1px 1px 2px 0px #333; cursor: pointer; text-decoration: none;">
+      Réinitialiser mon mot de passe
+  </a>
+</p>
+
+<p>Ou utiliser ce lien :<br /><a href="<%= passwordResetUrlWithToken %>"><%= passwordResetUrlWithToken %></a></p>
+
+<p>Si tu n'est pas à l'origine de cette demande tu peux ignorer ce message.</p>
+
+<p>🤖 Le secrétariat</p>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -38,7 +38,7 @@
 
   <div class="panel border-left-primary">
       <h6>⚠️&nbsp;Problème d'accès à ton adresse @<%= domain %> ?</h6>
-      Si tu as <strong>oublié ton mot de passe</strong> : demande de l'aide sur le Slack #incubateur-secretariat, un des administrateurs pourra t'aider.<br />
+      Si tu as <strong>oublié ton mot de passe</strong> clique <a href="/passwordReset">ici pour le réinitialiser</a>.<br />
       Si tu as besoin d'aide pour <strong>configurer ton client webmail</strong> : regarde la <a href="https://doc.incubateur.net/communaute/outils/emails#jai-un-email-beta-comment-me-connecter" target="_blank" title="lien vers la documentation pour se connecter à sa boite mail">documentation de l'incubateur</a>.
   </div>
 </div>

--- a/views/passwordReset.ejs
+++ b/views/passwordReset.ejs
@@ -1,0 +1,30 @@
+<%- include('partials/header'); -%>
+
+<div class="container container-small">
+
+  <% if (errors.length) { %>
+    <div class="notification error">
+      <strong>Erreur : </strong><%= errors %>
+    </div>
+  <% } %>
+
+  <div class="panel margin-top-m">
+    <h4>J'ai perdu mon mot de passe</h4>
+
+    <% if (messages.length) { %>
+      <div class="notification"><%- messages %></div>
+    <% } else { %>
+      <form action="/passwordReset" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
+        <label for="email">
+          <strong>Mon adresse email pro/perso</strong><br />
+          Renseigne l'email secondaire que tu as mis sur le formulaire d'inscription, et non pas ton email <%= domain %>.
+        </label>
+        <div class="input__group">
+          <input name="email" placeholder="Adresse email" required>
+        </div>
+        <button class="button" type="submit">Recevoir le lien de connexion</button>
+        <span>Ce lien sera valable 1h.</span>
+      </form>
+    <% } %>
+  </div>
+</div>

--- a/views/passwordResetEmailSent.ejs
+++ b/views/passwordResetEmailSent.ejs
@@ -1,0 +1,12 @@
+<%- include('partials/header'); -%>
+<div class="container container-small">
+
+<div class="panel margin-top-m">
+    <h4>Email de réinitialisation envoyé</h4>
+
+    <p>
+        Vérifie ta messagerie pour réinitialiser ton mot de passe.
+    </p>
+  </div>
+
+</div>

--- a/views/passwordResetForm.ejs
+++ b/views/passwordResetForm.ejs
@@ -1,0 +1,34 @@
+<%- include('partials/header'); -%>
+
+<div class="container container-small">
+
+    <% if (errors.length) { %>
+        <div class="notification error">
+        <strong>Erreur : </strong><%= errors %>
+        </div>
+    <% } %>
+
+    <div class="panel margin-top-m">
+        <h4>Mot de passe oublié</h4>
+
+        <% if (messages.length) { %>
+        <div class="notification"><%- messages %></div>
+        <% } else { %>
+        <form action="/passwordReset/form" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
+            <label for="password1">Nouveau mot de passe</label>
+            <div class="input__group">
+            <input name="password1" type="password" minlength="9" required>
+            </div>
+
+            <label for="password2">Confirmez votre nouveau mot de passe</label>
+            <div class="input__group">
+            <input name="password2" type="password" minlength="9" required>
+            </div>
+
+            <input type="hidden" name="token" value="<%= token %>" />
+
+            <button class="button" type="submit">Réinitialiser mon mot de passe</button>
+        </form>
+        <% } %>
+    </div>
+</div>


### PR DESCRIPTION
PR faite par @lbois et moi.

Le flow de base est le suivant :
![image](https://user-images.githubusercontent.com/1225929/106154460-e96e6880-617f-11eb-8954-46ddd537f857.png)

Plusieurs détails techniques ouverts à discussion :
- **Nous avons crée une nouvelle table _password_reset_tokens_ identique à l'existante _login_tokens_**
Nous pensons que garder les deux tables indépendants fera que l'email de login envoyé ne sera pas invalidé par une requête de changement de mot de passe. Est-ce que cela vous semble raisonable ?

- **L'utilisateur qui clique sur le lien de réinitialisation de mot de passe n'est pas automatiquement identifié**
Vu que l'email est envoyé à l'addresse perso/pro, nous n'étions pas super à l'aise avec un login automatique - cela reviendrait à pouvoir s'identifier avec un email perso. À discuter aussi.

- **Nous affichons clairement si l'email renseigné ne corresponde pas à un utilisateur connu**
C'est utile d'un point de vue UI/UX surtout dans notre cas où des utilisateurs existants ne pourront pas réinitialiser leur mot de passe car on n'a pas leur email secondaire. Par contre, il a des [discussions sur la sécurité de cette pratique](https://security.stackexchange.com/questions/40694/disclose-to-user-if-account-exists).

@astranchet N'hésite pas à modifier les messages/emails/etc directement dans la branche si tu préférés. 
@jdauphant je veux bien ton avis (surtout pour le dernier point coté securité)