### PR TITLE
fix(onboarding): add domain information to render html file

### DIFF
--- a/controllers/onboardingController.js
+++ b/controllers/onboardingController.js
@@ -208,6 +208,7 @@ module.exports.postForm = async function (req, res) {
       messages: req.flash('message'),
       userConfig: config.user,
       startups,
+      domain: config.domain,
       users,
       formData: req.body,
       useSelectList: isMobileFirefox,


### PR DESCRIPTION
# But
Sur le formulaire POST de http://localhost:8100/onboarding l'information `domain` était manquante ce qui rendait impossible l'affichage aprés l'envoie du formulaire