### PR TITLE
lint: remove-no-underscore-dangle

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,7 @@ parserOptions:
   ecmaVersion: 12
 
 rules:
+  no-underscore-dangle: "off"
   no-unused-vars: "off"
   no-inner-declarations: "off"
   no-console: "off"


### PR DESCRIPTION
# But
L'utilisation de la librarie `rewire` fait utiliser des fonctions appellées `__get__` que le linter n'apprecie pas, il faut activer cette règle

- https://eslint.org/docs/rules/no-underscore-dangle

Merci à l'oeil de lynx, AKA @LucasCharrier pour avoir repéré ce problème