### PR TITLE
chores(login): remove html from controller code

### DIFF
--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -27,13 +27,13 @@ async function sendLoginEmail(username, loginUrl, token) {
 
   if (!user) {
     throw new Error(
-      `Membre <strong>${username}</strong> inconnu·e sur ${config.domain}. Avez-vous une fiche sur Github ?`,
+      `Membre ${username} inconnu·e sur ${config.domain}. Avez-vous une fiche sur Github ?`,
     );
   }
 
   if (utils.checkUserIsExpired(user)) {
     throw new Error(
-      `Membre <strong>${username}</strong> a une date de fin expiré sur Github.`,
+      `Membre ${username} a une date de fin expiré sur Github.`,
     );
   }
 
@@ -93,7 +93,7 @@ module.exports.postLogin = async function (req, res) {
     await saveToken(username, token);
 
     return renderLogin(req, res, {
-      messages: req.flash('message', `Un lien de connexion a été envoyé à l'adresse <strong>${username}@${config.domain}</strong>. Il est valable une heure.`),
+      messages: req.flash('message', `Un lien de connexion a été envoyé à l'adresse ${username}@${config.domain}. Il est valable une heure.`),
     });
   } catch (err) {
     console.error(err);

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -16,7 +16,7 @@
     <h4>Me connecter</h4>
 
     <% if (messages.length) { %>
-      <div class="notification"><%- messages %></div>
+      <div class="notification"><%= messages %></div>
     <% } else { %>
       <form action="/login<%= nextParam %>" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
         <label for="username">Adresse email :</label>


### PR DESCRIPTION
Concerne https://github.com/betagouv/secretariat/issues/421

Le controlleur JS utilise du HTML qui n'est pas traduit depuis cette remarque https://github.com/betagouv/secretariat/pull/280#discussion_r515539497

Le but de cette PR est de supprimer le HTML venant des controlleurs

## Exemple
![erreur_utilisateur_secretariat](https://user-images.githubusercontent.com/4059615/106445424-4b301a80-647f-11eb-8661-42ced349a5ff.png)