### PR TITLE
Rend possible l'envoi du token d'identification vers l'adresse email secondaire

### DIFF
--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -95,7 +95,7 @@ module.exports.postLogin = async function (req, res) {
       const dbResponse = await knex('users').select('secondary_email').where({ username });
       if (dbResponse.length === 0 || !dbResponse[0].secondary_email) {
         throw new Error(
-          `Membre ${username} n'a pas renseigné d'adresse email secondaire. Si tu as perdu l'accès à ton compte email : demande de l'aide sur le Slack #incubateur-secretariat.`,
+          `Ton compte ${utils.buildBetaEmail(username)} n'a pas d'email secondaire. Si tu ne reçois pas le lien de connexion, tu peux demander de l'aide sur Slack #incubateur-secretariat ou à secretariat@beta.gouv.fr`,
         );
       }
       email = dbResponse[0].secondary_email;

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -95,7 +95,7 @@ module.exports.postLogin = async function (req, res) {
       const dbResponse = await knex('users').select('secondary_email').where({ username });
       if (dbResponse.length === 0 || !dbResponse[0].secondary_email) {
         throw new Error(
-          `Ton compte ${utils.buildBetaEmail(username)} n'a pas d'email secondaire. Si tu ne reçois pas le lien de connexion, tu peux demander de l'aide sur Slack #incubateur-secretariat ou à secretariat@beta.gouv.fr`,
+          `Ton compte ${utils.buildBetaEmail(username)} n'a pas d'email secondaire. Si tu ne reçois pas le lien de connexion, tu peux demander de l'aide sur Slack #incubateur-secretariat ou à secretariat@beta.gouv.fr.`,
         );
       }
       email = dbResponse[0].secondary_email;

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -95,7 +95,7 @@ module.exports.postLogin = async function (req, res) {
       const dbResponse = await knex('users').select('secondary_email').where({ username });
       if (dbResponse.length === 0 || !dbResponse[0].secondary_email) {
         throw new Error(
-          `Membre ${username} n'a pas renseigné d'adresse email secondaire. Si tu as perdu l'accès à ton compte email : demande de l'aide sur le Slack #incubateur-secretariat.`, // TODO: message
+          `Membre ${username} n'a pas renseigné d'adresse email secondaire. Si tu as perdu l'accès à ton compte email : demande de l'aide sur le Slack #incubateur-secretariat.`,
         );
       }
       email = dbResponse[0].secondary_email;

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -95,7 +95,7 @@ module.exports.postLogin = async function (req, res) {
       const dbResponse = await knex('users').select('secondary_email').where({ username });
       if (dbResponse.length === 0 || !dbResponse[0].secondary_email) {
         throw new Error(
-          `Membre ${username} n'a pas renseigné d'adresse email secondaire. Si tu as oublié ton mot de passe : demande de l'aide sur le Slack #incubateur-secretariat.`, // TODO: message
+          `Membre ${username} n'a pas renseigné d'adresse email secondaire. Si tu as perdu l'accès à ton compte email : demande de l'aide sur le Slack #incubateur-secretariat.`, // TODO: message
         );
       }
       email = dbResponse[0].secondary_email;

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -22,7 +22,7 @@ function generateToken() {
   return crypto.randomBytes(256).toString('base64');
 }
 
-async function sendLoginEmail(username, loginUrl, token) {
+async function sendLoginEmail(email, username, loginUrl, token) {
   const user = await BetaGouv.userInfosById(username);
 
   if (!user) {
@@ -37,7 +37,6 @@ async function sendLoginEmail(username, loginUrl, token) {
     );
   }
 
-  const email = utils.buildBetaEmail(username);
   const html = await ejs.renderFile('./views/emails/login.ejs', {
     loginUrlWithToken: `${loginUrl}?token=${encodeURIComponent(token)}`,
   });
@@ -75,7 +74,8 @@ module.exports.getLogin = async function (req, res) {
 
 module.exports.postLogin = async function (req, res) {
   const nextParam = req.query.next ? `?next=${req.query.next}` : '';
-  const { username } = req.body;
+  const { username, useSecondaryEmail } = req.body;
+
   if (
     username === undefined
     || !/^[a-z0-9_-]+\.[a-z0-9_-]+$/.test(username)
@@ -89,11 +89,25 @@ module.exports.postLogin = async function (req, res) {
 
   try {
     const token = generateToken();
-    await sendLoginEmail(username, loginUrl, token);
+
+    let email;
+    if (useSecondaryEmail) {
+      const dbResponse = await knex('users').select('secondary_email').where({ username });
+      if (dbResponse.length === 0 || !dbResponse[0].secondary_email) {
+        throw new Error(
+          `Membre ${username} n'a pas renseigné d'adresse email secondaire. Si tu as oublié ton mot de passe : demande de l'aide sur le Slack #incubateur-secretariat.`, // TODO: message
+        );
+      }
+      email = dbResponse[0].secondary_email;
+    } else {
+      email = utils.buildBetaEmail(username);
+    }
+
+    await sendLoginEmail(email, username, loginUrl, token);
     await saveToken(username, token);
 
     return renderLogin(req, res, {
-      messages: req.flash('message', `Un lien de connexion a été envoyé à l'adresse ${username}@${config.domain}. Il est valable une heure.`),
+      messages: req.flash('message', `Un lien de connexion a été envoyé à l'adresse ${email}. Il est valable une heure.`),
     });
   } catch (err) {
     console.error(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2413,7 +2413,10 @@
     "full-icu": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
-      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw=="
+      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2813,6 +2816,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
     },
     "ignore": {
       "version": "4.0.6",

--- a/tests/test-home.js
+++ b/tests/test-home.js
@@ -24,7 +24,7 @@ describe('Home', () => {
         .end((err, res) => {
           res.text.should.include('<form action="/login" method="POST"');
           res.text.should.include('<input name="username"');
-          res.text.should.include('<button class="button" type="submit">');
+          res.text.should.include('<button class="button" id="primary_email_button">');
           done();
         });
     });

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -18,15 +18,34 @@
     <% if (messages.length) { %>
       <div class="notification"><%= messages %></div>
     <% } else { %>
-      <form action="/login<%= nextParam %>" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
+      <form action="/login<%= nextParam %>" method="POST" id="login_form" onsubmit="event.submitter && (event.submitter.disabled = true);">
         <label for="username">Adresse email :</label>
         <div class="input__group">
           <input name="username" class="width-50" placeholder="prenom.nom" pattern="[a-z0-9_-]+\.[a-z0-9_-]+" autocomplete="username">
           <span class="padding-10">@<%= domain %></span>
         </div>
-        <button class="button" type="submit">Recevoir le lien de connexion</button>
+        <input type="hidden" name="useSecondaryEmail" id="secondary_email_input" value="" />
+        <button class="button" id="primary_email_button">Recevoir le lien de connexion</button>
         <span>Ce lien sera valable 1h.</span>
+
+        <div class="margin-10-0">
+          <a id="secondary_email_button">
+            Recevoir le lien de connexion à mon adresse secondaire
+          </a>
+        </div>
       </form>
+      <script>
+        const secondaryEmailInput = document.getElementById('secondary_email_input');
+        const loginForm = document.getElementById('login_form');
+        document.getElementById('primary_email_button').addEventListener('click', () => {
+          secondaryEmailInput.value = '';
+          loginForm.submit();
+        })
+        document.getElementById('secondary_email_button').addEventListener('click', () => {
+          secondaryEmailInput.value = true;
+          loginForm.submit();
+        })
+      </script>
     <% } %>
   </div>
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -30,7 +30,7 @@
 
         <div class="margin-10-0">
           <a id="secondary_email_button">
-            Recevoir le lien de connexion à mon adresse secondaire
+            Recevoir le lien de connexion sur mon adresse secondaire
           </a>
         </div>
       </form>


### PR DESCRIPTION
PR en pair-programming avec @lbois 

Permet d'envoyer le token d'identification à l'adresse email secondaire.

En cas d'absence d'adresse email secondaire, un message est affiché.

Note: On utilise du javascript dans le formulaire login pour renseigner un champ invisible qui permet le contrôleur de savoir vers quel adresse envoyer le token. Ceci peut poser des problèmes aux utilisateurs sans javascript activé (d'autres templates ont aussi des bouts en javascript, et on inclut des librairies JS pour les drawers dans le frontend).

![image](https://user-images.githubusercontent.com/1225929/107062810-fa4f5780-67d9-11eb-8477-54ebf6a9bd53.png)

![image](https://user-images.githubusercontent.com/1225929/107063096-41d5e380-67da-11eb-9088-826720b7ca65.png)

