### PR TITLE
Ajouter du username pour le referent par défaut

### DIFF
--- a/views/visit.ejs
+++ b/views/visit.ejs
@@ -72,7 +72,7 @@
                             <% }) %>
                 </datalist>
             <% } %>
-            <input type="hidden" name="${type}Username" id="${type}-${id}-hidden">
+            <input type="hidden" name="${type}Username" id="${type}-${id}-hidden" value="${user ? user.id : ''}">
         <br><br>`
         parent.insertBefore(element.content, sibling);
         document.getElementById(`${type}-${id}`).addEventListener('input', (e) => {


### PR DESCRIPTION
Encore une erreur. Comme j'ai un autocomplete au moment de l'ajout du numéro, je ne m'en étais pas rendu compte, mais le champs referentUsername n'était pas remplit automatiquement si aucune action sur l'input 'référent' effectuer.