### PR TITLE
Définir le sujet de l'email  comme étant le titre du contenu du pad

### DIFF
--- a/lib/mdtohtml.js
+++ b/lib/mdtohtml.js
@@ -174,6 +174,36 @@ overflow: visible !important;
 }
 `;
 
+module.exports.getTitle = function (content) {
+  const renderer = new marked.Renderer();
+
+  const toc = [];
+
+  renderer.heading = function (text, level, raw) {
+    const anchor = this.options.headerPrefix + raw.toLowerCase().replace(/[^\w]+/g, '-');
+    toc.push({
+      anchor,
+      level,
+      text,
+      raw,
+    });
+    return `<h${
+      level
+    } id="${
+      anchor
+    }">${
+      text
+    }</h${
+      level
+    }>\n`;
+  };
+  marked.setOptions({
+    renderer,
+  });
+  marked(content);
+  return toc[0].raw;
+};
+
 module.exports.renderHtmlFromMd = function (content) {
   const toc = [];
   const rendererFunc = (function () {

--- a/schedulers/newsletterScheduler.js
+++ b/schedulers/newsletterScheduler.js
@@ -5,7 +5,7 @@ const BetaGouv = require('../betagouv');
 const config = require('../config');
 const knex = require('../db');
 const utils = require('../controllers/utils');
-const { renderHtmlFromMd } = require('../lib/mdtohtml');
+const { renderHtmlFromMd, getTitle } = require('../lib/mdtohtml');
 
 const {
   NUMBER_OF_DAY_IN_A_WEEK,
@@ -152,7 +152,7 @@ const sendNewsletter = async () => {
     const newsletterContent = await pad.getNoteWithId(newsletterCurrentId);
     const html = renderHtmlFromMd(newsletterContent);
     await utils.sendMail(config.newsletterBroadcastList,
-      `Infolettre interne de la communauté beta.gouv.fr du ${utils.formatDateToFrenchTextReadableFormat(date)}`,
+      `${getTitle(newsletterContent)}`,
       html);
     await knex('newsletters').where({
       year_week: newsletterYearWeek,

--- a/tests/test-newsletter.js
+++ b/tests/test-newsletter.js
@@ -10,7 +10,7 @@ const BetaGouv = require('../betagouv');
 const app = require('../index');
 const controllerUtils = require('../controllers/utils');
 const utils = require('./utils');
-const { renderHtmlFromMd } = require('../lib/mdtohtml');
+const { renderHtmlFromMd, getTitle } = require('../lib/mdtohtml');
 
 const should = chai.should();
 
@@ -240,7 +240,7 @@ describe('Newsletter', () => {
       padGetDownloadCall.isDone().should.be.true;
       padPostLoginCall.isDone().should.be.true;
       sendEmailStub.calledOnce.should.be.true;
-      sendEmailStub.firstCall.args[1].should.equal(`Infolettre interne de la communauté beta.gouv.fr du ${controllerUtils.formatDateToFrenchTextReadableFormat(date)}`);
+      sendEmailStub.firstCall.args[1].should.equal('📰 Infolettre interne de la communauté beta.gouv.fr du REMPLACER_PAR_DATE');
       sendEmailStub.firstCall.args[2].should.equal(renderHtmlFromMd(NEWSLETTER_TEMPLATE_CONTENT));
       this.slack.notCalled.should.be.true;
       const newsletter = await knex('newsletters').where({


### PR DESCRIPTION
Afin d'avoir le même sujet dans l'email et dans le titre de la newsletter, le sujet de l'email est obtenu en extrayant le titre de la newsletter dans le contenu du pad.