### PR TITLE
Changement de wording pour marrainage

### DIFF
--- a/controllers/marrainageController.js
+++ b/controllers/marrainageController.js
@@ -76,7 +76,7 @@ async function sendOnboarderRequestEmail(newcomer, onboarder) {
 }
 
 function redirectOutdatedMarrainage(req, res) {
-  req.flash('message', "Merci de ta réponse. Après 48 h, nous demandons automatiquement à quelqu'un d'autre. Ce sera pour une prochaine fois 🙂");
+  req.flash('message', "Merci de ta réponse. Cette demande n'est plus d'actualité. Ce sera pour une prochaine fois 🙂");
   return res.redirect('/');
 }
 

--- a/views/emails/marrainageRequest.ejs
+++ b/views/emails/marrainageRequest.ejs
@@ -23,6 +23,10 @@ Par exemple, pour prendre un café virtuel avec il/elle et lui parler un peu de 
 </p>
 
 <p style="color: #999;font-size: 0.85em;">
+  Si tu ne réponds pas à ce message dans les 2 jours, nous considérerons que tu n'es pas disponible. Nous demanderons automatiquement à quelqu'un d'autre d'accueillir.
+</p>
+
+<p style="color: #999;font-size: 0.85em;">
   Cet email t’as été envoyé parce que tu es considéré comme membre de la communauté et qu’un algorithme aléatoire a pensé que tu étais 
   la meilleure personne pour ça :innocence:. Si tu ne veux plus recevoir ce type de messages, signale-le à <a href="mailto:secretariat@beta.gouv.fr">secretariat@beta.gouv.fr</a>.
 </p>


### PR DESCRIPTION
Closes #505 

@astranchet J'ai une question par rapport au wording, il y a deux types d'erreur : 

## 1- Quand le JWT token expire

C'est le souci levé par #505, qui nous donne un message "_jwt expired_". Dans ce cas j'ai remplacé par ton message "_Merci de ta réponse. Après 48 h, nous demandons automatiquement à quelqu'un d'autre. Ce sera pour une prochaine fois 🙂_" :+1: 

## 2- Quand soit on a déjà accepté/décliné, ou que 48h sont passés, ou que la nouvelle recrue a décidé d'annuler la procédure

Le souci c'est qu'on ne peut pas savoir dans quel cas on se trouve (on ne garde pas l'historique des demandes, seulement la dernière). Avant on avait un "_Il n'y a pas de demande de marrainage existant pour cette personne (vous avez peut-être déjà accepté ou refusé cette demande)_", qui couvre le premier cas. Là j'ai remplacé par le même message  "_Merci de ta réponse. Après 48 h, nous demandons automatiquement à quelqu'un d'autre. Ce sera pour une prochaine fois 🙂_" qui couvre seulement la seconde. 

Est-ce qu'on met un message plus générale ? Genre "_Cette demande de marrainage n'est plus d'actualité. Ceci peut arriver après 48h de la demande initiale ou bien après déjà avoir accepté ou refusé la demande_" - bon c'est nul mais un truc comme ça qui puisse regrouper les différentes raisons, tu en penses quoi ?