### PR TITLE
Change le nom du standup => "Hebdo beta.gouv"

### DIFF
--- a/schedulers/newsletterScheduler.js
+++ b/schedulers/newsletterScheduler.js
@@ -65,10 +65,10 @@ const computeMessageReminder = (reminder, newsletter) => {
   let message;
   if (reminder === 'FIRST_REMINDER') {
     message = `*Newsletter interne* :loudspeaker: : voici le pad de la semaine ${newsletter.url}.
-      Remplissez le pad avec vos news/annonces/événements qui seront présentées au standup.
+      Remplissez le pad avec vos news/annonces/événements qui seront présentées à l'hebdo beta.gouv.
       Le pad sera envoyé à la communauté vendredi.`;
   } else if (reminder === 'SECOND_REMINDER') {
-    message = `*:wave: Retrouvez nous pour le standup à midi sur http://invites.standup.incubateur.net/*
+    message = `*:wave: Retrouvez nous pour l'hebdo beta.gouv à midi sur http://invites.standup.incubateur.net/*
       Remplissez le pad avec vos news/annonces/événements ${newsletter.url}.
       Le pad sera envoyé à la communauté vendredi.`;
   } else {

--- a/tests/test-newsletter.js
+++ b/tests/test-newsletter.js
@@ -28,14 +28,14 @@ const {
 
 const NEWSLETTER_TITLE = '📰 Infolettre interne de la communauté beta.gouv.fr du __REMPLACER_PAR_DATE__';
 const NEWSLETTER_TEMPLATE_CONTENT = `# ${NEWSLETTER_TITLE}
-  Les nouvelles pourront être lu au point hebdomadaire (stand-up) le jeudi à 12h (pour rappel l'adresse du point hebdomadaire standup http://invites.standup.incubateur.net/ )
+  Les nouvelles pourront être lu à l'hebdo beta.gouv le jeudi à 12h (pour rappel l'adresse du point hebdomadaire http://invites.standup.incubateur.net/ )
   Vous pouvez consulter cette infolettre [en ligne](__REMPLACER_PAR_LIEN_DU_PAD__).
   ### Modèle d'annonce d'une Startup (Présenté par Jeanne Doe)
   ## Nouveautés transverses
   *Documentation : [Comment lancer ou participer à un sujet transverse](https://doc.incubateur.net/communaute/travailler-a-beta-gouv/actions-transverses)*
   ## Annonces des recrutements
   ## :calendar: Evénements à venir
-  ### 👋 Prochain point hebdomadaire (stand-up), jeudi __REMPLACER_PAR_DATE_STAND_UP__ à 12h
+  ### 👋 Prochain point hebdo beta.gouv, jeudi __REMPLACER_PAR_DATE_STAND_UP__ à 12h
 `;
 
 const newsletterScheduler = rewire('../schedulers/newsletterScheduler');

--- a/views/newsletter.ejs
+++ b/views/newsletter.ejs
@@ -7,7 +7,7 @@
             <a href="<%= currentNewsletter.url %>" target="_blank"><%= currentNewsletter.url %></a>
             <br>
             <br>
-            <p>L'infolettre est lue et partagée pendant le standup (chaque jeudi à 12h) puis envoyée après validation à partir de jeudi 18h</p>
+            <p>L'infolettre est lue et partagée pendant l'hebdo beta.gouv (chaque jeudi à 12h) puis envoyée après validation à partir de jeudi 18h</p>
             <% if (currentNewsletter.validator) { %>
                 <p><%= currentNewsletter.validator %> a validé cette infolettre.</p>
                 <form class="no-margin" action="/cancelNewsletter">


### PR DESCRIPTION
En séminaire du 29 avril 2021, il a été décidé de remplacer le nom du standup du jeudi par "Hebdo beta.gouv"