### PR TITLE
Proposition pour cacher l'email secondaire lors du login

### DIFF
--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -68,6 +68,19 @@ async function saveToken(username, token) {
   }
 }
 
+function censorEmail(email) {
+  const username = email.split('@')[0];
+  const domainSegments = email.split('@')[1].split('.');
+  const topLevelDomain = domainSegments[domainSegments.length - 1];
+  const emailHost = domainSegments.slice(0, -1).join('');
+
+  function censorWord(str) {
+    return str.length <= 5 ? str[0] + '*'.repeat(str.length - 1) : str[0] + '*'.repeat(str.length - 2) + str.slice(-1);
+  }
+
+  return `${censorWord(username)}@${censorWord(emailHost)}.${censorWord(topLevelDomain)}`;
+}
+
 module.exports.getLogin = async function (req, res) {
   renderLogin(req, res, {});
 };
@@ -106,8 +119,9 @@ module.exports.postLogin = async function (req, res) {
     await sendLoginEmail(email, username, loginUrl, token);
     await saveToken(username, token);
 
+    const displayEmail = useSecondaryEmail ? censorEmail(email) : email;
     return renderLogin(req, res, {
-      messages: req.flash('message', `Un lien de connexion a été envoyé à l'adresse ${email}. Il est valable une heure.`),
+      messages: req.flash('message', `Un lien de connexion a été envoyé à l'adresse ${displayEmail}. Il est valable une heure.`),
     });
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
Suite à la suggestion de @astranchet et @jdauphant cette PR vise à cacher certains caractères de l'email secondaire pour éviter de le montrer en entier, vous en pensez quoi ?

Pour cette première proposition la règle est la suivante : 
- On prend trois segments : l'username, le host, et le TLD <_username_>@<_host_>.<_tld_>. Par ex, pour un email "nom.prenom@beta.gouv.fr", username serait "nom.prenom", host serait "beta.gouv", et TLD serait "fr".
- Pour chaque de ces éléments, si ça fait moins de 5 caractères on garde le premier et le dernier caractère et on remplit le reste avec des étoiles (par ex _n********m_ pour _nom.prenom_), sinon on garde seulement le premier (par ex _f*_ pour _fr_).
- On recolle les morceaux, donc "nom.prenom@beta.gouv.fr" devient `n********m@b*******v.f*`.

![image](https://user-images.githubusercontent.com/1225929/116661147-4acaf100-a994-11eb-86c3-3833a3591702.png)
