### PR TITLE
Ajout message d'attention sur github à l'onboarding

### DIFF
--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -66,6 +66,7 @@
                 <label for="github">
                     <span>Nom d'utilisateur Github - sans l'@ et sans l'URL</span><br />
                     Si tu as un compte, tu peux être ajouté à l'organisation Github BetaGouv.
+                    <b>Si tu n'as pas de compte Github ou tu ne sais pas ce que c'est Github : ne met rien rien dans ce champs !</b>
                 </label>
                 <input name="github" pattern="^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$"
                     value="<%= formData.github %>"

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -66,7 +66,7 @@
                 <label for="github">
                     <span>Nom d'utilisateur Github - sans l'@ et sans l'URL</span><br />
                     Si tu as un compte, tu peux être ajouté à l'organisation Github BetaGouv.
-                    <b>Si tu n'as pas de compte Github ou tu ne sais pas ce que c'est Github : ne met rien rien dans ce champs !</b>
+                    <b>Si tu n'as pas de compte Github ou tu ne sais pas ce que c'est Github : ne mets rien rien dans ce champs !</b>
                 </label>
                 <input name="github" pattern="^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$"
                     value="<%= formData.github %>"


### PR DESCRIPTION
C'est arrivé 2 fois, des gens ont mis leur prénom comme compte github : 
- Une fois une personne étrangére a été invité à l'orga et nous l'a signé (alexia)
- L'autre fois, j'ai corrigé avant le merge (theo)

Il y a peut être d'autres cas.
Il y a peut-être d'autre contre-mesure possible : 
- comme une case à cocher "J'ai un compte github"
- un "login with github" pour valider le compte
- Supprimer github à cette étape