### PR TITLE
Simplification du champ "github" dans l'onboarding

### DIFF
--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -64,14 +64,12 @@
 
             <div class="form__group">
                 <label for="github">
-                    <span>Nom d'utilisateur Github - sans l'@ et sans l'URL</span><br />
-                    Si tu as un compte, tu peux être ajouté à l'organisation Github BetaGouv.
-                    <b>Si tu n'as pas de compte Github ou tu ne sais pas ce que c'est Github : ne mets rien rien dans ce champs !</b>
+                    <strong>Nom d'utilisateur Github (sans @)</strong>
                 </label>
+                <p>Si tu ne sais pas ce qu'est Github, laisse ce champ vide.</p>
                 <input name="github" pattern="^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$"
                     value="<%= formData.github %>"
-                    title="Pas d'url, juste ton nom d'utilisateur Github sans l'@"
-                    placeholder="Pas d'url, juste ton nom d'utilisateur Github sans l'@">
+                    title="Nom d'utilisateur Github (sans @)">
             </div>
 
 


### PR DESCRIPTION
Je refais une PR car je n'ai pas été assez rapide pour faire mes retour sur https://github.com/betagouv/secretariat/pull/553/files 

Dans cette PR  : 
- séparation entre libellé et champ d'aide
- simplification du champ d'aide
- suppression du placeholder (pas accessible et redondant).
- suppression de la faute d'orthographe :D 

Je n'ai pas les compétences pour mais idéalement, c'est le formulaire qui prévient les erreurs, pas les usagers. Exemple : `@astranchet` et `https://github.com/astranchet` sont des valeurs valides, le système se charge de les traduire en astranchet.

Dans ce contexte, j'ai choisi d'enlever la phrase d'indication sur "ajouté à l'organisation" : 
- peu d'utilisateurs ont le bagage technique pour la comprendre
- elle est moins importante que la consigne