### PR TITLE
Permet de continuer le cron marrainage en cas d'erreur

### DIFF
--- a/src/controllers/marrainageController.js
+++ b/src/controllers/marrainageController.js
@@ -83,6 +83,10 @@ function redirectOutdatedMarrainage(req, res) {
 module.exports.reloadMarrainage = async function (newcomerId) {
   const newcomer = await BetaGouv.userInfosById(newcomerId);
 
+  if (!newcomer) {
+    throw new Error(`${newcomerId} ne fais pas partie de la communauté beta.gouv`);
+  }
+
   const marrainageDetailsReponse = await knex('marrainage').select()
     .where({ username: newcomer.id, completed: false });
 

--- a/src/schedulers/marrainageScheduler.js
+++ b/src/schedulers/marrainageScheduler.js
@@ -13,13 +13,17 @@ const reloadMarrainages = async function () {
 
   const reloadItems = [];
   for (let i = 0; i < marrainageDetailsResponse.length; i += 1) {
-    try {
-      reloadItems.push(reloadMarrainage(marrainageDetailsResponse[i].username));
-    } catch (err) {
-      console.error(err);
-    }
+    reloadItems.push(reloadMarrainage(marrainageDetailsResponse[i].username)
+    .then(() => {
+      console.log(`Cron de marranaige a relancé ${marrainageDetailsResponse[i].username}`);
+    })
+    .catch((error) => {
+      console.error(`Cron de marrainage n'a pas pu relancer ${marrainageDetailsResponse[i].username} : ${error.message}`);
+    }));
   }
-  return Promise.all(reloadItems);
+  return Promise.all(reloadItems)
+    .then(() => console.log('Cron de marranaige terminé'))
+    .catch(console.error);
 };
 
 module.exports.reloadMarrainageJob = new CronJob(


### PR DESCRIPTION
L'erreur en prod résulte des entrées dans la table "marrainage" des utilisateurs qui ne font pas partie de beta.gouv - soit parce qu'ils sont partis avant que le marrainage aboutisse, soit à cause d'un changement dans le nom de leur fichier.

Aujourd'hui le cron s'arrête en cas d'erreur et ne relance pas les autres comptes. Cette PR vise à ne pas s’arrêter en cas de souci avec une entrée et de mieux logger pour qu'on puisse isoler les cas qui posent problème.  

Dans un second temps on pourrait décider de supprimer les lignes qui sont dans cet état programmatiquement.

Closes #592 