### PR TITLE
Masquage de la création de redirections

### DIFF
--- a/views/account.ejs
+++ b/views/account.ejs
@@ -179,6 +179,7 @@
                         </div>
                     <% }) %>
                     <% if (canCreateRedirection) { %>
+                        <!--
                         <form class="no-margin" action="/users/<%= userInfos.id %>/redirections" method="POST" onsubmit="event.submitter && (event.submitter.disabled = true);">
                             <div class="form__group">
                                 <label for="to_email">Rediriger mes mails <%= domain %> vers :</label>
@@ -190,6 +191,7 @@
                             </div>
                             <button class="button no-margin" type="submit">Ajouter la redirection</button>
                         </form>
+                        -->
                     <% } else { %>
                         <% if (isExpired) { %>
                         <div class="notification error">


### PR DESCRIPTION
Les redirections entrainent beaucoup d'erreurs : 
- des messages perdus pour le destinataire
- des renvois d'erreurs à des agents qui écrivent aux newsletters
- la suppression à la main d'une redirection par un administrateur est complexe

Je propose de masquer la possibilité d'en faire (pour une suppression futur).
On peut voir les retours des personnes qui en auraient absolument besoin.

Les méthodes alternatives sont l'usage de POP et IMAP.