### PR TITLE
Does not create emails for expired users

### DIFF
--- a/src/controllers/utils.js
+++ b/src/controllers/utils.js
@@ -57,6 +57,7 @@ module.exports.checkUserIsExpired = function (user) {
   // - son/sa date de fin est passée
   return user
     && user.end !== undefined
+    && new Date().toString() !== 'Invalid Date'
     && new Date(user.end).getTime() < new Date().getTime();
 };
 

--- a/src/schedulers/emailCreationScheduler.js
+++ b/src/schedulers/emailCreationScheduler.js
@@ -37,12 +37,17 @@ const getUnregisteredOVHUsers = async (githubUsers) => {
   return _.differenceWith(githubUsers, allOvhEmails, differenceGithubOVH);
 };
 
+const getValidUsers = async () => {
+  const githubUsers = await BetaGouv.usersInfos();
+  return githubUsers.filter((x) => !utils.checkUserIsExpired(x));
+};
+
 module.exports.createEmailAddresses = async function createEmailAddresses() {
   console.log('Demarrage du cron job pour la création des adresses email');
 
   const dbUsers = await knex('users').whereNotNull('secondary_email');
 
-  const githubUsers = await BetaGouv.usersInfos();
+  const githubUsers = await getValidUsers();
 
   const concernedUsers = githubUsers.reduce((acc, user) => {
     const dbUser = dbUsers.find((x) => x.username === user.id);

--- a/tests/test-email-creation.js
+++ b/tests/test-email-creation.js
@@ -29,6 +29,15 @@ describe('getUnregisteredOVHUsers', () => {
     result[0].fullname.should.be.equal(newMember.fullname);
   });
 
+  it('should not use expired accounts', async () => {
+    utils.mockUsers();
+    const expiredMember = testUsers.find((user) => user.id === 'membre.expire');
+    const getValidUsers = emailCreationScheduler.__get__('getValidUsers');
+    const result = await getValidUsers(testUsers);
+
+    chai.should().not.exist(result.find((x) => x.id === expiredMember.id));
+  });
+
   it('should return no accounts if there is no new ones in github', async () => {
     nock(/.*ovh.com/)
     .get(/^.*email\/domain\/.*\/account/)

--- a/tests/users.json
+++ b/tests/users.json
@@ -140,7 +140,6 @@
     "missions": [
       { 
         "start": "2018-03-27",
-        "end": "",
         "status": "admin",
         "employer": "Ministère de la Culture"
       }


### PR DESCRIPTION
Ne permet pas au bot de créer des comptes pour les utilsateurs.

Dans un second temps il faudra supprimer les emails secondaires de la DB pour les utilisateurs partis.