### PR TITLE
chores: automate docker-compose start with migrate/seed/env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Une fois Postgres lancé, vous pouvez démarrer l'application avec ces commandes
 ```
 L'application sera disponible sur `http://localhost:8100` (8100 est le port par défaut, vous pouvez le changer avec la variable d'env `PORT`)
 
+### Lancer avec docker-compose
+- Créer le fichier de configuration : `cp .env.example .env` et le remplir avec les identifiants OVH obtenus plus haut.
+- Lancer le service et initialiser la base de données : `docker-compose up` - disponible sur http://localhost:8100
+- Pour ajouter des données à la base de données (facultatif): `docker-compose run web npm run seed;`
+- Lancer les tests : `docker-compose run web npm test`
+
+### Lancer avec docker sans docker-compose
+
+- Exemple pour développer dans un container :
+	- `docker run --rm --env-file ../.env.secretariat.dev -v $(pwd):/app -w /app -ti -p 8100 node /bin/bash` (avec vos variables d'environnement dans ../.env.secretariat.dev)
+
 ### Lancer en mode production
 
 ```
@@ -141,17 +152,6 @@ Pour utiliser d'autres commandes, le [CLI de KnexJS](http://knexjs.org/#Migratio
 
 - Configurer les variables d'environnements : `OVH_APP_KEY`, `OVH_APP_SECRET` et `OVH_CONSUMER_KEY` (Avec une clé ayant un accès aux emails)
 - Lancer le script : `node ./scripts/delete_redirections.js from@beta.gouv.fr to@example.com`
-
-### Dev docker-compose
-- Créer le fichier de configuration : `cp .env.example .env` et le remplir avec les identifiants OVH obtenus plus haut.
-- Lancer le service et initialiser la base de données : `docker-compose up` - disponible sur http://localhost:8100
-- Lancer les tests : `docker-compose run web npm test`
-
-### Dev docker sans docker-compose
-
-- Exemple pour développer dans un container :
-	- `docker run --rm --env-file ../.env.secretariat.dev -v $(pwd):/app -w /app -ti -p 8100 node /bin/bash` (avec vos variables d'environnement dans ../.env.secretariat.dev)
-
 
 ## Explication du fonctionnement des pull requests Github
 

--- a/README.md
+++ b/README.md
@@ -144,10 +144,7 @@ Pour utiliser d'autres commandes, le [CLI de KnexJS](http://knexjs.org/#Migratio
 
 ### Dev docker-compose
 - Créer le fichier de configuration : `cp .env.example .env` et le remplir avec les identifiants OVH obtenus plus haut.
-- Récupérer les dépendences : `docker-compose run web npm install`
-- Créer les tables : `docker-compose run web npm run migrate`
-- Lancer le seeding : `docker-compose run web npm run seed`
-- Lancer le service : `docker-compose up` - Y accèder par http://localhost:8100
+- Lancer le service et initialiser la base de données : `docker-compose up` - disponible sur http://localhost:8100
 - Lancer les tests : `docker-compose run web npm test`
 
 ### Dev docker sans docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       - "1025:25"
   web:
     build: .
-    command: npm run dev
-    links:
+    command:  bash -c "echo 'first npm install can be a bit long'; npm install; npm run migrate; npm run seed; npm run dev"
+    depends_on:
       - db
       - maildev
     env_file: 
@@ -31,10 +31,12 @@ services:
       MAIL_PORT: 25
       MAIL_IGNORE_TLS: "true"
       SECURE: "false"
-      HOSTNAME: "localhost"
+      HOSTNAME: "web"
+      MAIL_HOST: "maildev"
       SESSION_SECRET: "SecretThatShouldChangedInProduction"
     ports:
       - "8100:8100"
       - "9229:9229"
     volumes:
       - .:/app
+    restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - "1025:25"
   web:
     build: .
-    command:  bash -c "echo 'first npm install can be a bit long'; npm install; npm run migrate; npm run seed; npm run dev"
+    command:  bash -c "echo 'first npm install can be a bit long'; npm install; npm run migrate; npm run dev"
     depends_on:
       - db
       - maildev
@@ -31,8 +31,7 @@ services:
       MAIL_PORT: 25
       MAIL_IGNORE_TLS: "true"
       SECURE: "false"
-      HOSTNAME: "web"
-      MAIL_HOST: "maildev"
+      HOSTNAME: localhost
       SESSION_SECRET: "SecretThatShouldChangedInProduction"
     ports:
       - "8100:8100"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: '3'
 services:
   db:
-    image: postgres
+    image: postgres:12.5
     environment:
       POSTGRES_USER: secretariat
       POSTGRES_PASSWORD: secretariat
     ports:
       - "5432:5432"
   maildev:
-    image: maildev/maildev
+    image: maildev/maildev:1.1.0
     environment: 
       MAILDEV_INCOMING_USER: mailuser
       MAILDEV_INCOMING_PASS: mailpassword

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,4 +143,4 @@ app.get('/cancelNewsletter', newsletterController.cancelNewsletter);
 
 sentry.initCaptureConsoleWithHandler(app);
 
-module.exports = app.listen(config.port, () => console.log(`Running on port: ${config.port}`));
+module.exports = app.listen(config.port, () => console.log(`Running on port: http://localhost:${config.port}`));

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,4 +143,4 @@ app.get('/cancelNewsletter', newsletterController.cancelNewsletter);
 
 sentry.initCaptureConsoleWithHandler(app);
 
-module.exports = app.listen(config.port, () => console.log(`Running on port: http://localhost:${config.port}`));
+module.exports = app.listen(config.port, () => console.log(`Running on port: http://${config.host}:${config.port}`));


### PR DESCRIPTION
## But

N'avoir qu'une seule commande pour lancer le service en local avec docker-compose

## Modifications
* logs de démarrage cliquable (http://localhost:8100/) au lieu de 8100
* grouper `npm run migrate` / `install` dans le container web