### PR TITLE
Add .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/


### PR DESCRIPTION
Permet d'ignorer le dossier `dist` pour les gens utilisant eslint et n'utilisant pas docker :)