### PR TITLE
Add the resources page

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Le secrétariat de l’incubateur
    - `MAIL_PORT` - Si la variable `MAIL_SERVICE` est absente, cette variable sera utilisée pour spécifier le port à utiliser pour l'envoi d'emails avec [Nodemailer](https://nodemailer.com/smtp/).
    - `MAIL_IGNORE_TLS` - Si la variable `MAIL_SERVICE` est absente, cette variable sera utilisée pour l'utilisation de TLS dans la connexion email avec [Nodemailer](https://nodemailer.com/smtp/).
    - `NEWSLETTER_HASH_SECRET` - Clé pour générer un id pour les newsletters, important en prod
+   - `INVESTIGATION_REPORTS_IFRAME_URL` - URL de l'iframe Airtable contenant les bilans d'investigations et qui est intégrée à la page ressources
 
 ### Lancer en mode développement
 

--- a/src/config.js
+++ b/src/config.js
@@ -45,4 +45,5 @@ module.exports = {
   sentryDNS: process.env.SENTRY_DNS || false,
   mattermostBotToken: process.env.MATTERMOST_BOT_TOKEN,
   mattermostTeamId: process.env.MATTERMOST_TEAM_ID || 'testteam',
+  investigationReportsIframeURL: process.env.INVESTIGATION_REPORTS_IFRAME_URL || '',
 };

--- a/src/controllers/resourceController.js
+++ b/src/controllers/resourceController.js
@@ -1,0 +1,12 @@
+const config = require('../config');
+
+module.exports.getResources = function (req, res) {
+  res.render('resource', {
+    title: 'Ressources',
+    activeTab: 'resources',
+    currentUserId: req.user.id,
+    errors: req.flash('error'),
+    messages: req.flash('message'),
+    investigationReportsIframeURL: config.investigationReportsIframeURL,
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ const adminController = require('./controllers/adminController');
 const onboardingController = require('./controllers/onboardingController');
 const visitController = require('./controllers/visitController');
 const newsletterController = require('./controllers/newsletterController');
+const resourceController = require('./controllers/resourceController');
 
 const app = express();
 
@@ -140,6 +141,8 @@ app.get('/onboardingSuccess/:prNumber', onboardingController.getConfirmation);
 app.get('/newsletters', newsletterController.getNewsletter);
 app.get('/validateNewsletter', newsletterController.validateNewsletter);
 app.get('/cancelNewsletter', newsletterController.cancelNewsletter);
+
+app.get('/resources', resourceController.getResources);
 
 sentry.initCaptureConsoleWithHandler(app);
 

--- a/tests/test-resource.js
+++ b/tests/test-resource.js
@@ -1,0 +1,32 @@
+const chai = require('chai');
+
+const app = require('../src/index.ts');
+const utils = require('./utils');
+
+describe('Resource', () => {
+  describe('GET /resources unauthenticated', () => {
+    it('should redirect to login', (done) => {
+      chai.request(app)
+        .get('/resources')
+        .redirects(0)
+        .end((err, res) => {
+          res.should.have.status(302);
+          res.headers.location.should.include('/login');
+          res.headers.location.should.equal('/login?next=/resources');
+          done();
+        });
+    });
+  });
+
+  describe('GET /resources authenticated', () => {
+    it('should return a valid page', (done) => {
+      chai.request(app)
+        .get('/resources')
+        .set('Cookie', `token=${utils.getJWT('membre.actif')}`)
+        .end((err, res) => {
+          res.should.have.status(200);
+          done();
+        });
+    });
+  });
+});

--- a/views/partials/nav-header.ejs
+++ b/views/partials/nav-header.ejs
@@ -46,6 +46,12 @@
                         Infolettres internes
                     </a>
                 </li>
+                <li>
+                    <a href="/resources" id="resources"
+                        class="nav-item <% if(activeTab === 'resources') { %> active <% } %>">
+                        Ressources
+                    </a>
+                </li>
                 <li class="nav-end">
                     <hr />
                     <% if (currentUserId) { %>

--- a/views/resource.ejs
+++ b/views/resource.ejs
@@ -1,0 +1,41 @@
+<%- include('partials/nav-header'); -%>
+
+<link rel="stylesheet" media="screen,print" href='/static/collapse/collapse.css'>
+<script src="/static/collapse/collapse.js"></script>
+
+<div class="module">
+
+    <div class="panel panel-full-width">
+        <h3>
+            Ressources
+        </h3>
+        <p>
+            Ressources et liens d'invitations privés aux ressources communes à la communauté.
+        </p>
+
+        <div class="collapse">
+            <h6 class="margin-10-0 collapse-header">
+                <button aria-expanded="false">
+                    Bilans d'investigations
+                    <div class="icon fa fa-chevron-down"></div>
+                </button>
+            </h6>
+            <div hidden class="collapse-content">
+                <% if (investigationReportsIframeURL) { %>
+                <iframe src="<%= investigationReportsIframeURL %>"
+                        frameborder="0" onmousewheel="" width="100%" height="533"
+                        style="background: transparent; border: 1px solid #ccc;">
+                </iframe>
+                <% } else { %>
+                <p>
+                    L'URL des bilans d'investigation n'est pas configurée.
+                </p>
+                <% } %>
+            </div>
+        </div>
+
+
+    </div>
+
+</div>
+<%- include('partials/nav-footer'); -%>


### PR DESCRIPTION
Nouvelle page Ressources avec seulement l'iframe des bilans d'investigation

L'URL de l'iframe airtable se configure via la variable d'environnement **INVESTIGATION_REPORTS_IFRAME_URL** et se renseigne avec une URL de la forme **https://airtable.com/embed/MON_ID_AIRTABLE?backgroundColor=orange&viewControls=on**.

Rendu avec l'URL configurée :
![image](https://user-images.githubusercontent.com/8938024/123079406-34816480-d41c-11eb-80a5-72746b009484.png)

Rendu quand l'URL n'est pas configurée :
![image](https://user-images.githubusercontent.com/8938024/123079526-52e76000-d41c-11eb-9ca9-da360994b949.png)

Issues liées :
- resolve #634
- #88 