### PR TITLE
Display the secondary email in users' cards

### DIFF
--- a/src/controllers/accountController.js
+++ b/src/controllers/accountController.js
@@ -4,10 +4,18 @@ const knex = require('../db');
 
 module.exports.getCurrentAccount = async function (req, res) {
   try {
-    const currentUser = await utils.userInfos(req.user.id, true);
-    const marrainageStateResponse = await knex('marrainage').select()
-      .where({ username: req.user.id });
-    const marrainageState = marrainageStateResponse[0];
+    const [currentUser, marrainageState, secondaryEmail] = await Promise.all([
+      (async () => utils.userInfos(req.user.id, true))(),
+      (async () => {
+        const [state] = await knex('marrainage').where({ username: req.user.id });
+        return state;
+      })(),
+      (async () => {
+        const rows = await knex('users').where({ username: req.user.id });
+        return rows.length === 1 ? rows[0].secondary_email : null;
+      })(),
+    ]);
+
     const title = 'Mon compte';
     return res.render('account', {
       title,
@@ -22,6 +30,7 @@ module.exports.getCurrentAccount = async function (req, res) {
       redirections: currentUser.redirections,
       activeTab: 'account',
       marrainageState,
+      secondaryEmail,
       errors: req.flash('error'),
       messages: req.flash('message'),
     });

--- a/tests/test-community.js
+++ b/tests/test-community.js
@@ -85,6 +85,32 @@ describe('Community', () => {
         });
     });
 
+    it('should show the secondary email if it exists', (done) => {
+      knex('users')
+        .insert({
+          username: 'membre.parti',
+          secondary_email: 'perso@example.com',
+        }).then(() => {
+          chai.request(app)
+            .get('/community/membre.parti')
+            .set('Cookie', `token=${utils.getJWT('membre.actif')}`)
+            .end((err, res) => {
+              res.text.should.include('Email secondaire : </span> perso@example.com');
+              done();
+            });
+        });
+    });
+
+    it('should not show the secondary email if it does not exist', (done) => {
+      chai.request(app)
+        .get('/community/membre.parti')
+        .set('Cookie', `token=${utils.getJWT('membre.actif')}`)
+        .end((err, res) => {
+          res.text.should.include('Email secondaire : </span> Non renseigné');
+          done();
+        });
+    });
+
     it('should show the email creation form for email-less users', (done) => {
       chai.request(app)
         .get('/community/membre.parti')

--- a/views/account.ejs
+++ b/views/account.ejs
@@ -37,6 +37,9 @@
                         <% } %>
                     </p>
                     <% } %>
+                    <p>
+                        <span class="font-weight-bold">Email secondaire : </span> <%= secondaryEmail || 'Non renseigné' %>
+                    </p>
                 </div>
                 <div class="account-split-panel-shrink">
                     <img width="100%" src="/static/images/logo-betagouv.jpg" />

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -47,7 +47,11 @@
                                 Non renseigné
                             <% } %>
                         </p>
-                        <a class="button no-margin" href="https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/<%= username %>.md" target="_blank">Modifier sur Github</a> 
+                        <a class="button no-margin" href="https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/<%= username %>.md" target="_blank">Modifier sur Github</a>
+
+                        <p>
+                            <span class="font-weight-bold">Email secondaire : </span> <%= secondaryEmail || 'Non renseigné' %>
+                        </p>
                     </div>
                 <% } else { %>
                     <p>Il n'y a de fiche pour ce membre sur github</p>


### PR DESCRIPTION
Affichage de l'email secondaire des membres (table `users` de la BDD postgres) dans les fiches des utilisateurs.

Sur la fiche d'un membre :
![2021-06-23_18-28-36](https://user-images.githubusercontent.com/8938024/123136143-e20f6a80-d452-11eb-9158-8cd0fa50ec71.png)
![2021-06-23_18-29-28](https://user-images.githubusercontent.com/8938024/123136198-f05d8680-d452-11eb-8576-f0dd16f62c8e.png)

Dans la page mon compte :
![2021-06-23_18-30-09](https://user-images.githubusercontent.com/8938024/123136202-f2274a00-d452-11eb-9f8d-ca506bc781b1.png)

A noter que le html est différent, dans les 2 templates et le bouton Modifier sur github n'est pas au même endroit.
Cela fait que l'email secondaire se retrouve au dessus du bouton Modifier sur github dans la page Mon compte.
On peut changer ça si nécessaire.

resolve #615