### PR TITLE
Add a loading bar using buunguyen/topbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "promise-memoize": "^1.2.1",
         "raw-body": "^2.4.1",
         "template.data.gouv.fr": "^1.3.2",
+        "topbar": "^1.0.1",
         "ts-mocha": "^8.0.0",
         "uuid": "^8.3.2"
       },
@@ -8949,6 +8950,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/topbar": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/topbar/-/topbar-1.0.1.tgz",
+      "integrity": "sha512-HZqQSMBiG29vcjOrqKCM9iGY/h69G5gQH7ae83ZCPz5uPmbQKwK0sMEqzVDBiu64tWHJ+kk9NApECrF+FAAvRA=="
+    },
     "node_modules/touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
@@ -16942,6 +16948,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "topbar": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/topbar/-/topbar-1.0.1.tgz",
+      "integrity": "sha512-HZqQSMBiG29vcjOrqKCM9iGY/h69G5gQH7ae83ZCPz5uPmbQKwK0sMEqzVDBiu64tWHJ+kk9NApECrF+FAAvRA=="
     },
     "touch": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "promise-memoize": "^1.2.1",
     "raw-body": "^2.4.1",
     "template.data.gouv.fr": "^1.3.2",
+    "topbar": "^1.0.1",
     "ts-mocha": "^8.0.0",
     "uuid": "^8.3.2"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ app.use(compression());
 
 app.use('/static', express.static(path.join(__dirname, '../static')));
 app.use('/datagouvfr', express.static(path.join(__dirname, '../node_modules/template.data.gouv.fr/dist'))); // hack to mimick the behavior of webpack css-loader (used to import template.data.gouv.fr)
+app.use('/topbar.js', express.static(path.join(__dirname, '../node_modules/topbar/topbar.min.js')));
 
 app.use(cookieParser(config.secret));
 app.use(session({ cookie: { maxAge: 300000, sameSite: 'lax' } })); // Only used for Flash not safe for others purposes

--- a/views/marrainage.ejs
+++ b/views/marrainage.ejs
@@ -26,3 +26,5 @@
   <a class="button" href="/">Accéder à l'accueil du secrétariat</a>
 
 </div>
+
+<%- include('partials/footer'); -%>

--- a/views/newsletter.ejs
+++ b/views/newsletter.ejs
@@ -45,3 +45,4 @@
         </table>
     </div>
 </div>
+<%- include('partials/nav-footer'); -%>

--- a/views/onboarding.ejs
+++ b/views/onboarding.ejs
@@ -211,3 +211,4 @@
         </form>
     </div>
 </div>
+<%- include('partials/footer'); -%>

--- a/views/onboardingSuccess.ejs
+++ b/views/onboardingSuccess.ejs
@@ -14,3 +14,5 @@
         <p>À bientôt !</p>
     </div>
 </div>
+
+<%- include('partials/footer'); -%>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -17,3 +17,4 @@
     </footer>
   </body>
 </html>
+<%- include('loading-bar'); -%>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,7 +1,7 @@
       </section>
     </main>
     <footer id="footer">
-      <% if (currentUser) { %>
+      <% if (locals.currentUser) { %>
         <div class="margin-10-0">
           <a href="/community">Accueil</a> /
           Membre : <a href="/account"><%= currentUser.id %></a> /

--- a/views/partials/loading-bar.ejs
+++ b/views/partials/loading-bar.ejs
@@ -1,0 +1,22 @@
+<script src="/topbar.js"></script>
+<script>
+(function () {
+  "use strict"
+
+  // show the loading topbar when navigating on desktop only (mobile browsers already have their loading bar)
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+  if (!isMobile) {
+    topbar.config({
+      barColors: {
+        '0': 'rgb(0, 83, 179)' // same as var(--theme-primary) (blue)
+      }
+    })
+
+    window.addEventListener('beforeunload', () => {
+      setTimeout(() => {
+        topbar.show()
+      }, 500)
+    })
+  }
+}());
+</script>

--- a/views/partials/nav-footer.ejs
+++ b/views/partials/nav-footer.ejs
@@ -10,3 +10,4 @@
 </body>
 </html>
 <script src="/static/scripts/app.js"></script>
+<%- include('loading-bar'); -%>

--- a/views/visit.ejs
+++ b/views/visit.ejs
@@ -129,3 +129,4 @@
         createNewInputInParentBeforeSibling(visitorList, button, 'visitorList');
     });
 </script>
+<%- include('partials/nav-footer'); -%>


### PR DESCRIPTION
- Ajout d'une barre de chargement basée sur [buunguyen/topbar](https://github.com/buunguyen/topbar).
- Ajoute 1.4Ko (gzippé) à télécharger via le CDN unpkg.com
- La barre se déclenche aux changements de page, après 500ms. Cela évite que la barre s'affiche si la page se charge en dessous de ce délai.

- [x] ne pas afficher la barre sur mobile car une barre est déjà présente dans les navigateurs.

Notes :
- J'ai ajouté le script juste après `<script src="/static/scripts/app.js"></script>` qui est en dehors de la balise `<html>`. Je ne sais pas si c'était fait exprès à la base. :man_shrugging:
- Je n'affiche pas la barre sur mobile (testé sous Android Chrome + Firefox uniquement)

## Démo :

https://user-images.githubusercontent.com/8938024/123935656-b5001200-d994-11eb-827c-6c59008c1df7.mp4

Close #290