### PR TITLE
Delete the user if he closes his account

### DIFF
--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -245,6 +245,7 @@ module.exports.deleteEmailForUser = async function (req, res) {
     }
 
     await BetaGouv.deleteEmail(username);
+    await knex('users').where({ username }).del();
     console.log(`Supression de compte email de ${username} (à la demande de ${req.user.id})`);
 
     if (isCurrentUser) {


### PR DESCRIPTION
Description
-----------
Concerne l'issue #651 
Lorsqu'un compte est supprimé sur secrétariat, si une adresse email secondaire est enregistrée, le compte sera créé à nouveau. 

Changement
--------
Lors de la demande de suppression de compte, l'utilisateur est également supprimé dans la table `users`. 

Étant donné que cette table ne contient que le nom et l'adresse secondaire, j'ai choisis de supprimé l'utilisateur pour éviter d'avoir un problème de clef primaire existante (prenom.nom) si le compte est créé à nouveau.