### PR TITLE
Ajouter le lien de connexion à mattermost

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -45,5 +45,6 @@ module.exports = {
   sentryDNS: process.env.SENTRY_DNS || false,
   mattermostBotToken: process.env.MATTERMOST_BOT_TOKEN,
   mattermostTeamId: process.env.MATTERMOST_TEAM_ID || 'testteam',
+  mattermostInvitationLink: process.env.MATTERMOST_INVITATION_LINK || '',
   investigationReportsIframeURL: process.env.INVESTIGATION_REPORTS_IFRAME_URL || '',
 };

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -21,7 +21,12 @@ module.exports.createEmail = async function (username, creator, toEmail) {
   await BetaGouv.sendInfoToSlack(message);
   await BetaGouv.createEmail(username, password);
 
-  const html = await ejs.renderFile('./views/emails/createEmail.ejs', { email, password, secretariatUrl });
+  const html = await ejs.renderFile('./views/emails/createEmail.ejs', {
+    email,
+    password,
+    secretariatUrl,
+    mattermostInvitationLink: config.mattermostInvitationLink,
+  });
 
   try {
     await utils.sendMail(toEmail, 'Bienvenue chez BetaGouv 🙂', html);

--- a/views/emails/createEmail.ejs
+++ b/views/emails/createEmail.ejs
@@ -10,7 +10,7 @@
 <p>Et maintenant ?</p>
 <ul>
   <li>Étape 1 : Connecte toi à ton compte OVH une première fois sur le <a href="https://mail.ovh.net/roundcube/">Webmail OVH</a></li>
-  <li>Étape 2 : Rejoins-nous sur Mattermost en créant un compte avec ta nouvelle adresse beta.gouv : <a href="https://mattermost.incubateur.net">mattermost.incubateur.net</a></li>
+  <li>Étape 2 : Rejoins-nous sur Mattermost en créant un compte avec ta nouvelle adresse beta.gouv : <a href="<%= mattermostInvitationLink %>">mattermost.incubateur.net</a></li>
   <li>Étape 3 (optionnelle) : Configure ton email beta.gouv (configuration email, changement de mot de passe, etc.) sur l'application <a href="<%= secretariatUrl %>">Secrétariat</a></li> 
 </ul>
 

--- a/views/emails/createEmail.ejs
+++ b/views/emails/createEmail.ejs
@@ -10,7 +10,7 @@
 <p>Et maintenant ?</p>
 <ul>
   <li>Étape 1 : Connecte toi à ton compte OVH une première fois sur le <a href="https://mail.ovh.net/roundcube/">Webmail OVH</a></li>
-  <li>Étape 2 : Rejoins-nous sur Mattermost en créant un compte avec ta nouvelle adresse beta.gouv : <a href="<%= mattermostInvitationLink %>">mattermost.incubateur.net</a></li>
+  <li>Étape 2 : Rejoins-nous sur Mattermost en créant un compte avec ta nouvelle adresse beta.gouv : <a href="<%= mattermostInvitationLink %>"><%= mattermostInvitationLink %></a></li>
   <li>Étape 3 (optionnelle) : Configure ton email beta.gouv (configuration email, changement de mot de passe, etc.) sur l'application <a href="<%= secretariatUrl %>">Secrétariat</a></li> 
 </ul>
 


### PR DESCRIPTION
Ajoute le lien pour se créer un compte sur mattermost dans l'email d'onboarding. Le lien est défini par une variable d'environnement.