### PR TITLE
Add invite on mattemost by email, add create user on mattermost

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -35,6 +35,8 @@ jobs:
         SESSION_SECRET: fakesessionsecret
         SLACK_WEBHOOK_URL_SECRETARIAT: https://example.com
         SLACK_WEBHOOK_URL_GENERAL: https://example.com
+        MATTERMOST_BOT_TOKEN: faketoken
+        MATTERMOST_INVITE_ID: fakeid
         MAIL_PASS: fakepass
         MAIL_SERVICE: debug
         MAIL_USER: fakeuser

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ Le secrétariat de l’incubateur
    - `NEWSLETTER_HASH_SECRET` - Clé pour générer un id pour les newsletters, important en prod
    - `INVESTIGATION_REPORTS_IFRAME_URL` - URL de l'iframe Airtable contenant les bilans d'investigations et qui est intégrée à la page ressources
    - `GITHUB_ORGANIZATION_NAME` - Nom de l'organization github à laquelle inviter les membres
-
+   - `MATTERMOST_INVITE_ID` - ID secret de l'invitation qui permet de se créer un compte sur l'espace mattermost https://mattermost.incubateur.net/signup_user_complete/?id=[ID]
+   - `MATTERMOST_TEAM_ID` - ID de la team `Communauté`
+   - `MATTERMOST_BOT_TOKEN` - Token du bot mattermost qui permet de faire les requêtes à l'api
 
 ### Lancer en mode développement
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "express-session": "^1.17.2",
         "front-matter": "^4.0.2",
         "full-icu": "^1.3.4",
+        "generate-password": "^1.6.0",
         "hedgedoc-api": "git+https://github.com/betagouv/hedgedoc-api-lib-js.git#v1.0",
         "jsonwebtoken": "^8.2.2",
         "juice": "^8.0.0",
@@ -3198,6 +3199,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "node_modules/generate-password": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/generate-password/-/generate-password-1.6.0.tgz",
+      "integrity": "sha512-YUJTQkApkLT/fru0QdYWP0lVZdPKhF5kXCP24sgI4gR/vFMJFopCj5t1+9FAKIYcML/nxzx2PMkA1ymO1FC+tQ=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -10833,6 +10839,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "generate-password": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/generate-password/-/generate-password-1.6.0.tgz",
+      "integrity": "sha512-YUJTQkApkLT/fru0QdYWP0lVZdPKhF5kXCP24sgI4gR/vFMJFopCj5t1+9FAKIYcML/nxzx2PMkA1ymO1FC+tQ=="
     },
     "get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "express-session": "^1.17.2",
     "front-matter": "^4.0.2",
     "full-icu": "^1.3.4",
+    "generate-password": "^1.6.0",
     "hedgedoc-api": "git+https://github.com/betagouv/hedgedoc-api-lib-js.git#v1.0",
     "jsonwebtoken": "^8.2.2",
     "juice": "^8.0.0",

--- a/src/betagouv.js
+++ b/src/betagouv.js
@@ -6,7 +6,6 @@ const ovh = require('ovh')({
   appSecret: process.env.OVH_APP_SECRET,
   consumerKey: process.env.OVH_CONSUMER_KEY,
 });
-
 const config = require('./config');
 
 const betaGouv = {
@@ -65,6 +64,16 @@ const betaOVH = {
     } catch (err) {
       throw new Error(`OVH Error GET on ${url} : ${JSON.stringify(err)}`);
     }
+  },
+  // get active users with email registered on ovh
+  getActiveRegisteredOVHUsers: async () => {
+    const users = await betaGouv.usersInfos();
+    const allOvhEmails = await betaOVH.getAllEmailInfos();
+    const { checkUserIsExpired } = require('./controllers/utils');
+    const activeUsers = users.filter(
+      (user) => !checkUserIsExpired(user.id) && allOvhEmails.includes(user.id),
+    );
+    return activeUsers;
   },
   createEmail: async (id, password) => {
     const url = `/email/domain/${config.domain}/account`;

--- a/src/betagouv.js
+++ b/src/betagouv.js
@@ -57,6 +57,7 @@ const betaOVH = {
     }
   },
   getAllEmailInfos: async () => { // https://eu.api.ovh.com/console/#/email/domain/%7Bdomain%7D/account#GET
+    // result is an array of the users ids : ['firstname1.lastname1', 'firstname2.lastname2', ...]
     const url = `/email/domain/${config.domain}/account/`;
 
     try {

--- a/src/config.js
+++ b/src/config.js
@@ -54,4 +54,5 @@ module.exports = {
   investigationReportsIframeURL: process.env.INVESTIGATION_REPORTS_IFRAME_URL || '',
   leavesEmail: process.env.LEAVES_EMAIL || 'depart@beta.gouv.fr',
   featureAddGithubUserToOrganization: process.env.FEATURE_ADD_GITHUB_USER_TO_ORGANIZATION,
+  createUserOnMattermost: process.env.CREATE_USER_ON_MATTERMOST,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -51,7 +51,6 @@ module.exports = {
   mattermostTeamId: process.env.MATTERMOST_TEAM_ID || 'testteam',
   mattermostInvitationLink: process.env.MATTERMOST_INVITATION_LINK || '',
   mattermostInviteId: process.env.MATTERMOST_INVITE_ID,
-  mattermostDefaultPassword: process.env.MATTERMOST_DEFAULT_PASSWORD,
   investigationReportsIframeURL: process.env.INVESTIGATION_REPORTS_IFRAME_URL || '',
   leavesEmail: process.env.LEAVES_EMAIL || 'depart@beta.gouv.fr',
   featureAddGithubUserToOrganization: process.env.FEATURE_ADD_GITHUB_USER_TO_ORGANIZATION,

--- a/src/config.js
+++ b/src/config.js
@@ -50,6 +50,8 @@ module.exports = {
   mattermostBotToken: process.env.MATTERMOST_BOT_TOKEN,
   mattermostTeamId: process.env.MATTERMOST_TEAM_ID || 'testteam',
   mattermostInvitationLink: process.env.MATTERMOST_INVITATION_LINK || '',
+  mattermostInviteId: process.env.MATTERMOST_INVITE_ID,
+  mattermostDefaultPassword: process.env.MATTERMOST_DEFAULT_PASSWORD,
   investigationReportsIframeURL: process.env.INVESTIGATION_REPORTS_IFRAME_URL || '',
   leavesEmail: process.env.LEAVES_EMAIL || 'depart@beta.gouv.fr',
   featureAddGithubUserToOrganization: process.env.FEATURE_ADD_GITHUB_USER_TO_ORGANIZATION,

--- a/src/config.js
+++ b/src/config.js
@@ -54,5 +54,5 @@ module.exports = {
   investigationReportsIframeURL: process.env.INVESTIGATION_REPORTS_IFRAME_URL || '',
   leavesEmail: process.env.LEAVES_EMAIL || 'depart@beta.gouv.fr',
   featureAddGithubUserToOrganization: process.env.FEATURE_ADD_GITHUB_USER_TO_ORGANIZATION,
-  createUserOnMattermost: process.env.CREATE_USER_ON_MATTERMOST,
+  featureCreateUserOnMattermost: process.env.FEATURE_CREATE_USER_ON_MATTERMOST,
 };

--- a/src/lib/mattermost.js
+++ b/src/lib/mattermost.js
@@ -1,10 +1,17 @@
 const axios = require('axios').default;
 const config = require('../config');
 
-const mattermostConfig = {
-  headers: {
-    Authorization: `Bearer ${config.mattermostBotToken}`,
-  },
+const getMattermostConfig = () => {
+  if (!config.mattermostBotToken) {
+    const errorMessage = 'Unable to launch mattermost api calls without env var mattermostBotToken';
+    console.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+  return {
+    headers: {
+      Authorization: `Bearer ${config.mattermostBotToken}`,
+    },
+  };
 };
 
 module.exports.getUserWithParams = async (params, i = 0) => {
@@ -14,7 +21,7 @@ module.exports.getUserWithParams = async (params, i = 0) => {
       per_page: 200,
       page: i,
     },
-    ...mattermostConfig,
+    ...getMattermostConfig(),
   }).then((response) => response.data);
   if (!mattermostUsers.length) {
     return [];
@@ -29,7 +36,7 @@ module.exports.inviteUsersToTeamByEmail = async (userEmails, teamId) => {
     res = await axios.post(
       `https://mattermost.incubateur.net/api/v4/teams/${teamId}/invite/email`,
       userEmails,
-      mattermostConfig,
+      getMattermostConfig(),
     ).then((response) => response.data);
   } catch (err) {
     console.error('Erreur d\'ajout des utilisateurs à mattermost', err, userEmails);
@@ -40,6 +47,11 @@ module.exports.inviteUsersToTeamByEmail = async (userEmails, teamId) => {
 };
 
 module.exports.createUser = async ({ email, username, password }, teamId) => {
+  if (!config.mattermostInviteId) {
+    const errorMessage = 'Unable to launch createUser without env var mattermostInviteId';
+    console.error(errorMessage);
+    throw new Error(errorMessage);
+  }
   let res;
   try {
     res = await axios.post(
@@ -49,7 +61,7 @@ module.exports.createUser = async ({ email, username, password }, teamId) => {
         username,
         password,
       },
-      mattermostConfig,
+      getMattermostConfig(),
     ).then((response) => response.data);
   } catch (err) {
     console.error('Erreur d\'ajout des utilisateurs à mattermost', err, email, username);

--- a/src/lib/mattermost.js
+++ b/src/lib/mattermost.js
@@ -38,3 +38,23 @@ module.exports.inviteUsersToTeamByEmail = async (userEmails, teamId) => {
   console.log('Ajout des utilisateurs à mattermost', userEmails);
   return res;
 };
+
+module.exports.createUser = async ({ email, username, password }, teamId) => {
+  let res;
+  try {
+    res = await axios.post(
+      `https://mattermost.incubateur.net/api/v4/users?iid=${config.mattermostInviteId}`,
+      {
+        email,
+        username,
+        password,
+      },
+      mattermostConfig,
+    ).then((response) => response.data);
+  } catch (err) {
+    console.error('Erreur d\'ajout des utilisateurs à mattermost', err, email, username);
+    return;
+  }
+  console.log('Ajout de l\'utilisateur', email, username);
+  return res;
+};

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -15,3 +15,12 @@ if (config.featureAddGithubUserToOrganization) {
     'Europe/Paris',
   );
 }
+const { createUsersByEmail } = require('./mattermostScheduler');
+
+module.exports.createMattermostUsers = new CronJob(
+  '0 */8 * * * *',
+  module.exports.createUsersByEmail,
+  null,
+  true,
+  'Europe/Paris',
+);

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -16,11 +16,13 @@ if (config.featureAddGithubUserToOrganization) {
   );
 }
 const { createUsersByEmail } = require('./mattermostScheduler');
+// const { CronJob } = require('cron');
+// const { createUsersByEmail } = require('./mattermostScheduler');
 
-module.exports.createMattermostUsers = new CronJob(
-  '0 */8 * * * *',
-  createUsersByEmail,
-  null,
-  true,
-  'Europe/Paris',
-);
+// module.exports.createMattermostUsers = new CronJob(
+//   '0 */8 * * * *',
+//   createUsersByEmail,
+//   null,
+//   true,
+//   'Europe/Paris',
+// );

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -17,6 +17,7 @@ if (config.featureAddGithubUserToOrganization) {
 }
 
 if (config.featureCreateUserOnMattermost) {
+  console.log('Cron job to create user on mattermost by email on');
   const { createUsersByEmail } = require('./mattermostScheduler');
   const createMattermostUsers = new CronJob(
     '0 */8 * * * *',
@@ -25,4 +26,6 @@ if (config.featureCreateUserOnMattermost) {
     true,
     'Europe/Paris',
   );
+} else {
+  console.log('Cron job to create user on mattermost by email off');
 }

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -15,15 +15,14 @@ if (config.featureAddGithubUserToOrganization) {
     'Europe/Paris',
   );
 }
-const { createUsersByEmail } = require('./mattermostScheduler');
-// const { CronJob } = require('cron');
-// const { createUsersByEmail } = require('./mattermostScheduler');
-const { createUsersByEmail } = require('./mattermostScheduler');
 
-module.exports.createMattermostUsers = new CronJob(
-  '0 */8 * * * *',
-  createUsersByEmail,
-  null,
-  true,
-  'Europe/Paris',
-);
+if (!config.createUserOnMattermost) {
+  const { createUsersByEmail } = require('./mattermostScheduler');
+  const createMattermostUsers = new CronJob(
+    '0 */8 * * * *',
+    createUsersByEmail,
+    null,
+    true,
+    'Europe/Paris',
+  );
+}

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -18,11 +18,12 @@ if (config.featureAddGithubUserToOrganization) {
 const { createUsersByEmail } = require('./mattermostScheduler');
 // const { CronJob } = require('cron');
 // const { createUsersByEmail } = require('./mattermostScheduler');
+const { createUsersByEmail } = require('./mattermostScheduler');
 
-// module.exports.createMattermostUsers = new CronJob(
-//   '0 */8 * * * *',
-//   createUsersByEmail,
-//   null,
-//   true,
-//   'Europe/Paris',
-// );
+module.exports.createMattermostUsers = new CronJob(
+  '0 */8 * * * *',
+  createUsersByEmail,
+  null,
+  true,
+  'Europe/Paris',
+);

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -16,7 +16,7 @@ if (config.featureAddGithubUserToOrganization) {
   );
 }
 
-if (config.createUserOnMattermost) {
+if (config.featureCreateUserOnMattermost) {
   const { createUsersByEmail } = require('./mattermostScheduler');
   const createMattermostUsers = new CronJob(
     '0 */8 * * * *',

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -19,7 +19,7 @@ const { createUsersByEmail } = require('./mattermostScheduler');
 
 module.exports.createMattermostUsers = new CronJob(
   '0 */8 * * * *',
-  module.exports.createUsersByEmail,
+  createUsersByEmail,
   null,
   true,
   'Europe/Paris',

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -16,7 +16,7 @@ if (config.featureAddGithubUserToOrganization) {
   );
 }
 
-if (!config.createUserOnMattermost) {
+if (config.createUserOnMattermost) {
   const { createUsersByEmail } = require('./mattermostScheduler');
   const createMattermostUsers = new CronJob(
     '0 */8 * * * *',

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -5,6 +5,9 @@ const BetaGouv = require('../betagouv');
 const utils = require('../controllers/utils');
 
 const getActiveGithubUsersUnregisteredOnMattermost = async () => {
+  if (config.stagingUsers) {
+    return config.stagingUsers;
+  }
   const allMattermostUsers = await mattermost.getUserWithParams();
   const activeGithubUsers = await BetaGouv.getActiveRegisteredOVHUsers();
   const allMattermostUsersEmails = allMattermostUsers.map((mattermostUser) => mattermostUser.email);

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -35,10 +35,13 @@ module.exports.createUsersByEmail = async () => {
   });
   const results = await Promise.all(activeGithubUsersUnregisteredOnMattermost.map(async (user) => {
     const email = utils.buildBetaEmail(user.id);
+
     await mattermost.createUser({
       email,
       username: user.id,
-      password: generator.generateMultiple(3, {
+      // mattermost spec : password must contain at least 10 character,
+      // one lowercase, one upper, one number and a special character (amongst "~!@#$%^&*()").
+      password: generator.generate({
         length: 10,
         uppercase: true,
         numbers: true,

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -8,7 +8,7 @@ const getUnregisteredMemberActifs = async (activeGithubUsers, allMattermostUsers
   const activeGithubUsersEmails = activeGithubUsers.map((user) => `${user.id}@${config.domain}`);
   const allMattermostUsersEmails = allMattermostUsers.map((mattermostUser) => mattermostUser.email);
   const unregisteredMemberActifs = activeGithubUsersEmails.filter(
-    (user) => !allMattermostUsersEmails.includes(user.email),
+    (email) => !allMattermostUsersEmails.includes(email),
   );
   return unregisteredMemberActifs;
 };
@@ -22,7 +22,7 @@ module.exports.inviteUsersToTeamByEmail = async () => {
   });
   const unregisteredMemberActifs = await getUnregisteredMemberActifs(activeGithubUsers, allMattermostUsers);
   const results = await mattermost.inviteUsersToTeamByEmail(
-    unregisteredMemberActifs.map((member) => member.email), config.mattermostTeamId,
+    unregisteredMemberActifs.map((member) => member), config.mattermostTeamId,
   );
   return results;
 };

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -40,7 +40,7 @@ module.exports.createUsersByEmail = async () => {
       username: user.id,
       password: generator.generateMultiple(3, {
         length: 10,
-        uppercase: false,
+        uppercase: true,
         numbers: true,
         symbols: true,
       }),

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -4,32 +4,32 @@ const config = require('../config');
 const BetaGouv = require('../betagouv');
 const utils = require('../controllers/utils');
 
-const getActiveGithubUsersUnregistedOnMattermost = async () => {
+const getActiveGithubUsersUnregisteredOnMattermost = async () => {
   const allMattermostUsers = await mattermost.getUserWithParams();
   const activeGithubUsers = await BetaGouv.getActiveRegisteredOVHUsers();
   const allMattermostUsersEmails = allMattermostUsers.map((mattermostUser) => mattermostUser.email);
-  const activeGithubUsersUnregistedOnMattermost = activeGithubUsers.filter(
+  const activeGithubUsersUnregisteredOnMattermost = activeGithubUsers.filter(
     (user) => !allMattermostUsersEmails.includes(utils.buildBetaEmail(user.id)),
   );
-  return activeGithubUsersUnregistedOnMattermost;
+  return activeGithubUsersUnregisteredOnMattermost;
 };
 
 module.exports.inviteUsersToTeamByEmail = async () => {
-  const activeGithubUsersUnregistedOnMattermost = await getActiveGithubUsersUnregistedOnMattermost();
+  const activeGithubUsersUnregisteredOnMattermost = await getActiveGithubUsersUnregisteredOnMattermost();
   const results = await mattermost.inviteUsersToTeamByEmail(
-    activeGithubUsersUnregistedOnMattermost.map((user) => user.email).slice(0, 19), config.mattermostTeamId,
+    activeGithubUsersUnregisteredOnMattermost.map((user) => user.email).slice(0, 19), config.mattermostTeamId,
   );
   return results;
 };
 
 module.exports.createUsersByEmail = async () => {
-  let activeGithubUsersUnregistedOnMattermost = await getActiveGithubUsersUnregistedOnMattermost();
-  activeGithubUsersUnregistedOnMattermost = activeGithubUsersUnregistedOnMattermost.filter((user) => {
+  let activeGithubUsersUnregisteredOnMattermost = await getActiveGithubUsersUnregisteredOnMattermost();
+  activeGithubUsersUnregisteredOnMattermost = activeGithubUsersUnregisteredOnMattermost.filter((user) => {
     const userStartDate = new Date(user.start).getTime();
     // filter user that have have been created after implementation of this function
     return userStartDate >= new Date('2021-07-08').getTime();
   });
-  const results = await Promise.all(activeGithubUsersUnregistedOnMattermost.map(async (user) => {
+  const results = await Promise.all(activeGithubUsersUnregisteredOnMattermost.map(async (user) => {
     const email = utils.buildBetaEmail(user.id);
     await mattermost.createUser({
       email,

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -6,9 +6,6 @@ const BetaGouv = require('../betagouv');
 const utils = require('../controllers/utils');
 
 const getActiveGithubUsersUnregisteredOnMattermost = async () => {
-  if (config.stagingUsers) {
-    return config.stagingUsers;
-  }
   const allMattermostUsers = await mattermost.getUserWithParams();
   const activeGithubUsers = await BetaGouv.getActiveRegisteredOVHUsers();
   const allMattermostUsersEmails = allMattermostUsers.map((mattermostUser) => mattermostUser.email);

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -4,49 +4,43 @@ const config = require('../config');
 const BetaGouv = require('../betagouv');
 const utils = require('../controllers/utils');
 
-// get users that are member (got a github card) and mattermost account that is not in the team
-const getUnregisteredMemberActifs = async (activeGithubUsers, allMattermostUsers) => {
-  const activeGithubUsersEmails = activeGithubUsers.map((user) => `${user.id}@${config.domain}`);
+const getActiveGithubUsersUnregistedOnMattermost = async () => {
+  const allMattermostUsers = await mattermost.getUserWithParams();
+  const activeGithubUsers = await BetaGouv.getActiveRegisteredOVHUsers();
   const allMattermostUsersEmails = allMattermostUsers.map((mattermostUser) => mattermostUser.email);
-  const unregisteredMemberActifs = activeGithubUsersEmails.filter(
-    (email) => !allMattermostUsersEmails.includes(email),
+  const activeGithubUsersUnregistedOnMattermost = activeGithubUsers.filter(
+    (user) => !allMattermostUsersEmails.includes(utils.buildBetaEmail(user.id)),
   );
-  return unregisteredMemberActifs;
+  return activeGithubUsersUnregistedOnMattermost;
 };
 
 module.exports.inviteUsersToTeamByEmail = async () => {
-  const allMattermostUsers = await mattermost.getUserWithParams();
-  const users = await BetaGouv.usersInfos();
-  const activeGithubUsers = users.filter((x) => {
-    const stillActive = !utils.checkUserIsExpired(x);
-    return stillActive;
-  });
-  const unregisteredMemberActifs = await getUnregisteredMemberActifs(activeGithubUsers, allMattermostUsers);
+  const activeGithubUsersUnregistedOnMattermost = await getActiveGithubUsersUnregistedOnMattermost();
   const results = await mattermost.inviteUsersToTeamByEmail(
-    unregisteredMemberActifs.map((member) => member).slice(0, 19), config.mattermostTeamId,
+    activeGithubUsersUnregistedOnMattermost.map((user) => user.email).slice(0, 19), config.mattermostTeamId,
   );
   return results;
 };
 
 module.exports.createUsersByEmail = async () => {
-  const allMattermostUsers = await mattermost.getUserWithParams();
-  const users = await BetaGouv.usersInfos();
-  const activeGithubUsers = users.filter((user) => {
-    const stillActive = !utils.checkUserIsExpired(user);
-    return stillActive && new Date(user.start).getTime() >= new Date('2021-07-08').getTime();
+  let activeGithubUsersUnregistedOnMattermost = await getActiveGithubUsersUnregistedOnMattermost();
+  activeGithubUsersUnregistedOnMattermost = activeGithubUsersUnregistedOnMattermost.filter((user) => {
+    const userStartDate = new Date(user.start).getTime();
+    // filter user that have have been created after implementation of this function
+    return userStartDate >= new Date('2021-07-08').getTime();
   });
-  const unregisteredMemberActifs = await getUnregisteredMemberActifs(activeGithubUsers, allMattermostUsers);
-  const results = await Promise.all(unregisteredMemberActifs.map(async (email) => {
+  const results = await Promise.all(activeGithubUsersUnregistedOnMattermost.map(async (user) => {
+    const email = utils.buildBetaEmail(user.id);
     await mattermost.createUser({
       email,
-      username: email.split('@')[0],
+      username: user.id,
       password: config.mattermostDefaultPassword,
     });
 
     const html = await ejs.renderFile('./views/emails/mattermost.ejs', {
       resetPasswordLink: 'https://mattermost.incubateur.net/reset_password',
     });
-    await utils.sendMail(email, 'Bienvenue chez BetaGouv 🙂', html);
+    await utils.sendMail(email, 'Inscription à mattermost', html);
   }));
   return results;
 };

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -22,7 +22,6 @@ module.exports.inviteUsersToTeamByEmail = async () => {
     return stillActive;
   });
   const unregisteredMemberActifs = await getUnregisteredMemberActifs(activeGithubUsers, allMattermostUsers);
-  console.log(unregisteredMemberActifs);
   const results = await mattermost.inviteUsersToTeamByEmail(
     unregisteredMemberActifs.map((member) => member).slice(0, 19), config.mattermostTeamId,
   );

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -24,6 +24,9 @@ module.exports.inviteUsersToTeamByEmail = async () => {
 };
 
 module.exports.createUsersByEmail = async () => {
+  if (!config.createUserOnMattermost) {
+    return;
+  }
   let activeGithubUsersUnregisteredOnMattermost = await getActiveGithubUsersUnregisteredOnMattermost();
   activeGithubUsersUnregisteredOnMattermost = activeGithubUsersUnregisteredOnMattermost.filter((user) => {
     const userStartDate = new Date(user.start).getTime();

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -1,3 +1,4 @@
+const ejs = require('ejs');
 const mattermost = require('../lib/mattermost');
 const config = require('../config');
 const BetaGouv = require('../betagouv');
@@ -21,8 +22,32 @@ module.exports.inviteUsersToTeamByEmail = async () => {
     return stillActive;
   });
   const unregisteredMemberActifs = await getUnregisteredMemberActifs(activeGithubUsers, allMattermostUsers);
+  console.log(unregisteredMemberActifs);
   const results = await mattermost.inviteUsersToTeamByEmail(
-    unregisteredMemberActifs.map((member) => member), config.mattermostTeamId,
+    unregisteredMemberActifs.map((member) => member).slice(0, 19), config.mattermostTeamId,
   );
+  return results;
+};
+
+module.exports.createUsersByEmail = async () => {
+  const allMattermostUsers = await mattermost.getUserWithParams();
+  const users = await BetaGouv.usersInfos();
+  const activeGithubUsers = users.filter((user) => {
+    const stillActive = !utils.checkUserIsExpired(user);
+    return stillActive && new Date(user.start).getTime() >= new Date('2021-07-08').getTime();
+  });
+  const unregisteredMemberActifs = await getUnregisteredMemberActifs(activeGithubUsers, allMattermostUsers);
+  const results = await Promise.all(unregisteredMemberActifs.map(async (email) => {
+    await mattermost.createUser({
+      email,
+      username: email.split('@')[0],
+      password: config.mattermostDefaultPassword,
+    });
+
+    const html = await ejs.renderFile('./views/emails/mattermost.ejs', {
+      resetPasswordLink: 'https://mattermost.incubateur.net/reset_password',
+    });
+    await utils.sendMail(email, 'Bienvenue chez BetaGouv 🙂', html);
+  }));
   return results;
 };

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -1,4 +1,5 @@
 const ejs = require('ejs');
+const generator = require('generate-password');
 const mattermost = require('../lib/mattermost');
 const config = require('../config');
 const BetaGouv = require('../betagouv');
@@ -37,7 +38,12 @@ module.exports.createUsersByEmail = async () => {
     await mattermost.createUser({
       email,
       username: user.id,
-      password: config.mattermostDefaultPassword,
+      password: generator.generateMultiple(3, {
+        length: 10,
+        uppercase: false,
+        numbers: true,
+        symbols: true,
+      }),
     });
 
     const html = await ejs.renderFile('./views/emails/mattermost.ejs', {

--- a/src/schedulers/mattermostScheduler.js
+++ b/src/schedulers/mattermostScheduler.js
@@ -24,9 +24,6 @@ module.exports.inviteUsersToTeamByEmail = async () => {
 };
 
 module.exports.createUsersByEmail = async () => {
-  if (!config.createUserOnMattermost) {
-    return;
-  }
   let activeGithubUsersUnregisteredOnMattermost = await getActiveGithubUsersUnregisteredOnMattermost();
   activeGithubUsersUnregisteredOnMattermost = activeGithubUsersUnregisteredOnMattermost.filter((user) => {
     const userStartDate = new Date(user.start).getTime();

--- a/src/schedulers/newsletterScheduler.js
+++ b/src/schedulers/newsletterScheduler.js
@@ -115,8 +115,6 @@ module.exports.newsletterThursdayEveningReminderJob = new CronJob(
   'Europe/Paris',
 );
 
-
-
 const sendNewsletterAndCreateNewOne = async () => {
   const date = new Date();
   const currentNewsletter = await knex('newsletters').where({

--- a/src/schedulers/newsletterScheduler.js
+++ b/src/schedulers/newsletterScheduler.js
@@ -115,15 +115,7 @@ module.exports.newsletterThursdayEveningReminderJob = new CronJob(
   'Europe/Paris',
 );
 
-// get active users with email registered on ovh
-const getActiveRegisteredOVHUsers = async () => {
-  const users = await BetaGouv.usersInfos();
-  const allOvhEmails = await BetaGouv.getAllEmailInfos();
-  const activeUsers = users.filter(
-    (user) => !utils.checkUserIsExpired(user.id) && allOvhEmails.includes(user.id),
-  );
-  return activeUsers;
-};
+
 
 const sendNewsletterAndCreateNewOne = async () => {
   const date = new Date();
@@ -136,7 +128,7 @@ const sendNewsletterAndCreateNewOne = async () => {
     const newsletterCurrentId = currentNewsletter.url.replace(`${config.padURL}/`, '');
     const newsletterContent = await pad.getNoteWithId(newsletterCurrentId);
     const html = renderHtmlFromMd(newsletterContent);
-    const activeRegisteredOVHUsers = await getActiveRegisteredOVHUsers();
+    const activeRegisteredOVHUsers = await BetaGouv.getActiveRegisteredOVHUsers();
     const usersEmails = activeRegisteredOVHUsers.map(
       (user) => user.id,
     ).map(utils.buildBetaEmail);

--- a/src/scripts/createUsersByEmail.js
+++ b/src/scripts/createUsersByEmail.js
@@ -1,0 +1,3 @@
+const { createUsersByEmail } = require('../schedulers/mattermostScheduler');
+
+createUsersByEmail();

--- a/tests/test-mattermost.ts
+++ b/tests/test-mattermost.ts
@@ -47,14 +47,14 @@ describe('invite users to mattermost', () => {
     .get(/^.*email\/domain\/.*\/account/)
     .reply(200, testUsers.map((user) => user.id));
 
-    nock(/.*mattermost.incubateur.net/)
+    nock(/^.*mattermost.incubateur.net/)
     .get(/^.*api\/v4\/users.*/)
     .reply(200, [...mattermostUsers]);
     nock(/.*mattermost.incubateur.net/)
     .get(/^.*api\/v4\/users.*/)
     .reply(200, []);
 
-    nock(/.*mattermost.incubateur.net/)
+    nock(/^.*mattermost.incubateur.net/)
     .post(/^.*api\/v4\/teams\/testteam\/invite\/email.*/)
     .reply(200, [{}, {}]).persist();
 
@@ -73,7 +73,7 @@ describe('invite users to mattermost', () => {
     .get(/^.*email\/domain\/.*\/account/)
     .reply(200, testUsers.map((user) => user.id));
 
-    nock(/.*mattermost.incubateur.net/)
+    nock(/^.*mattermost.incubateur.net/)
     .get(/^.*api\/v4\/users.*/)
     .reply(200, [...mattermostUsers]);
     nock(/.*mattermost.incubateur.net/)

--- a/tests/test-mattermost.ts
+++ b/tests/test-mattermost.ts
@@ -63,7 +63,6 @@ describe('invite users to mattermost', () => {
     .persist();
     const { inviteUsersToTeamByEmail } = mattermostScheduler;
     const result = await inviteUsersToTeamByEmail();
-    console.log(result);
     result.length.should.be.equal(2);
   });
 

--- a/tests/test-mattermost.ts
+++ b/tests/test-mattermost.ts
@@ -33,6 +33,7 @@ describe('invite users to mattermost', () => {
     const date = new Date('2021-01-20T07:59:59+01:00');
     clock = sinon.useFakeTimers(date);
     utils.cleanMocks();
+    utils.mockOvhTime();
   });
 
   afterEach(async () => {
@@ -40,6 +41,10 @@ describe('invite users to mattermost', () => {
   });
 
   it('invite users to team by emails', async () => {
+    nock(/.*ovh.com/)
+    .get(/^.*email\/domain\/.*\/account/)
+    .reply(200, testUsers.map((user) => user.id));
+
     nock(/.*mattermost.incubateur.net/)
     .get(/^.*api\/v4\/users.*/)
     .reply(200, [...mattermostUsers]);
@@ -58,10 +63,15 @@ describe('invite users to mattermost', () => {
     .persist();
     const { inviteUsersToTeamByEmail } = mattermostScheduler;
     const result = await inviteUsersToTeamByEmail();
+    console.log(result);
     result.length.should.be.equal(2);
   });
 
   it('create users to team by emails', async () => {
+    nock(/.*ovh.com/)
+    .get(/^.*email\/domain\/.*\/account/)
+    .reply(200, testUsers.map((user) => user.id));
+
     nock(/.*mattermost.incubateur.net/)
     .get(/^.*api\/v4\/users.*/)
     .reply(200, [...mattermostUsers]);

--- a/tests/test-mattermost.ts
+++ b/tests/test-mattermost.ts
@@ -57,7 +57,7 @@ describe('invite users to mattermost', () => {
     .reply(200, testUsers)
     .persist();
     const { inviteUsersToTeamByEmail } = mattermostScheduler;
-    const result = await inviteUsersToTeamByEmail([...mattermostUsers]);
+    const result = await inviteUsersToTeamByEmail();
     result.length.should.be.equal(2);
   });
 
@@ -84,7 +84,7 @@ describe('invite users to mattermost', () => {
     result.length.should.be.equal(1);
     mattermostCreateUser.calledOnce.should.be.true;
     sendEmailStub.calledOnce.should.be.true;
-    sendEmailStub.restore()
+    sendEmailStub.restore();
     mattermostCreateUser.firstCall.args[0].email = `mattermost.newuser@${config.domain}`;
     mattermostCreateUser.firstCall.args[0].useranme = 'mattermost.newuser';
   });

--- a/tests/test-mattermost.ts
+++ b/tests/test-mattermost.ts
@@ -4,6 +4,8 @@ import sinon from 'sinon';
 import config from '../src/config';
 import testUsers from './users.json';
 import utils from './utils';
+import mattermost from '../src/lib/mattermost';
+import controllerUtils from '../src/controllers/utils';
 
 const mattermostUsers = [
   {

--- a/tests/test-mattermost.ts
+++ b/tests/test-mattermost.ts
@@ -47,14 +47,14 @@ describe('invite users to mattermost', () => {
     .get(/^.*email\/domain\/.*\/account/)
     .reply(200, testUsers.map((user) => user.id));
 
-    nock(/^.*mattermost.incubateur.net/)
+    nock(/.*mattermost.incubateur.net/)
     .get(/^.*api\/v4\/users.*/)
     .reply(200, [...mattermostUsers]);
     nock(/.*mattermost.incubateur.net/)
     .get(/^.*api\/v4\/users.*/)
     .reply(200, []);
 
-    nock(/^.*mattermost.incubateur.net/)
+    nock(/.*mattermost.incubateur.net/)
     .post(/^.*api\/v4\/teams\/testteam\/invite\/email.*/)
     .reply(200, [{}, {}]).persist();
 
@@ -73,7 +73,7 @@ describe('invite users to mattermost', () => {
     .get(/^.*email\/domain\/.*\/account/)
     .reply(200, testUsers.map((user) => user.id));
 
-    nock(/^.*mattermost.incubateur.net/)
+    nock(/.*mattermost.incubateur.net/)
     .get(/^.*api\/v4\/users.*/)
     .reply(200, [...mattermostUsers]);
     nock(/.*mattermost.incubateur.net/)

--- a/tests/users.json
+++ b/tests/users.json
@@ -182,5 +182,16 @@
         "employer": "dinsic"
       }
     ]
+  },
+  {
+    "id": "mattermost.newuser",
+    "fullname": "Mattermost Newuser",
+    "missions": [
+      { 
+        "start": "2021-07-09",
+        "end": "2021-12-24",
+        "employer": "dinsic"
+      }
+    ]
   }
 ]

--- a/views/emails/mattermost.ejs
+++ b/views/emails/mattermost.ejs
@@ -1,0 +1,20 @@
+<p>Hello ! 👋</p>
+
+<p>
+  Ton compte mattermost a été créé. 
+  Tu peux directement créer un nouveau password via le lien de reset password suivant.
+</p>
+
+<p style="margin: 30px 0px;">
+  <a 
+  href="<%= resetPasswordLink %>"
+  style="background: #006be6;padding: 10px 40px; border: none; border-radius: 3px; color: white; box-shadow: 1px 1px 2px 0px #333; cursor: pointer; text-decoration: none;">
+      Définir mon password
+  </a>
+</p>
+
+<p>Ou utiliser ce lien :<br /><a href="<%= resetPasswordLink %>"><%= resetPasswordLink %></a></p>
+
+<p>En cas de problème avec ton compte, n'hésite pas à répondre à ce mail !</p>
+
+<p>🤖 Le secrétariat</p>


### PR DESCRIPTION
Seule la fonction `createUser` de mattermost sera utilisé pour l'instant (j'ai laissé la fonction `invite` mais pour l'instant elle n'est pas utilisée).
Un cron job tourne régulièrement pour créer un utilisateur sur mattermost avec un mot de passe par défaut.
Le compte est créé si les conditions suivantes sont réunies : 
- une fiche github valide existe, 
-  le compte n'existe pas sur mattermost,
-  l'email existe dans ovh

Un email est envoyé à l'utilisateur pour qu'il se connecte à son compte en réinitialisant son mdp.