### PR TITLE
Added launch cron less often and remove logs

### DIFF
--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -9,7 +9,7 @@ if (config.featureAddGithubUserToOrganization) {
   const { addGithubUserToOrganization } = require('./githubScheduler');
 
   module.exports.addGithubUserToOrganization = new CronJob(
-    '0 */4 * * * 1-5',
+    '0 */15 * * * 1-5',
     addGithubUserToOrganization,
     null,
     true,

--- a/src/schedulers/githubScheduler.js
+++ b/src/schedulers/githubScheduler.js
@@ -24,13 +24,13 @@ const getGithubUserNotOnOrganization = async (org) => {
 };
 
 const addGithubUserToOrganization = async () => {
+  console.log('Launch add github users to organization');
   const githubUserNotOnOrganization = await getGithubUserNotOnOrganization(config.githubOrganizationName);
   const results = await Promise.all(githubUserNotOnOrganization.map(async (member) => {
     try {
       await github.inviteUserByUsernameToOrganization(member.github, config.githubOrganizationName);
-      console.log(`Add user ${member.github} to organization`);
     } catch (err) {
-      console.error(`Cannot add user ${member.github} to organization ${config.githubOrganizationName}. Error :`, err);
+      console.error(`Cannot add user ${member.github} to organization ${config.githubOrganizationName}. Error : ${err}`);
     }
   }));
 };


### PR DESCRIPTION
- retire des logs,
- fait tourner le cron moins souvent
J'ai retiré les logs sur les invitations des utilisateurs car elles sont relancés en permanence, et ça rajoute donc plein de ligne inutile. 
Je remettrai des logs si on fait un system pour identifier quelles invitations sont encore valides et non pas encore besoin d'être ré-envoyer.
