### PR TITLE
Adding script to remove marrainage for expired users

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -59,4 +59,5 @@ module.exports = {
   featureCreateUserOnMattermost: process.env.FEATURE_CREATE_USER_ON_MATTERMOST,
   featureRemoveGithubUserFromOrganization: process.env.FEATURE_REMOVE_GITHUB_USER_FROM_ORGANIZATION,
   featureOnUserContractEnd: process.env.FEATURE_ON_USER_CONTRACT_END,
+  featureRemoveMarrainageForExpiredUsers: process.env.FEATURE_REMOVE_MARRAINAGE_FOR_EXPIRED_USERS || false,
 };

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -286,7 +286,7 @@ module.exports.createSecondaryEmailForUser = async function (req, res) {
       await knex('users')
         .insert({
           secondary_email: secondaryEmail,
-          username
+          username,
         });
       req.flash('message', 'Ton compte email secondaire a bien été ajoutée.');
       res.redirect(`/community/${username}`);

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -56,7 +56,7 @@ if (config.featureCreateUserOnMattermost) {
 if (config.featureReactiveMattermostUsers) {
   const { reactivateUsers } = require('./mattermostScheduler');
   console.log('🚀 The job reactiveMattermostUsers is started');
-  new CronJob(
+  const reactiveUsers = new CronJob(
     '0 0 10 * * 1-5', // monday through friday at 10:00:00
     reactivateUsers,
     null,
@@ -88,4 +88,18 @@ if (config.featureOnUserContractEnd) {
   );
 } else {
   console.log('Send contract ending message job is off');
+}
+
+if (config.featureRemoveMarrainageForExpiredUsers) {
+  console.log('Create cron job for removing marrainage for expired users');
+  const { removeMarrainageForExpiredUsers } = require('./marrainageScheduler');
+  const removeMarrainage = new CronJob(
+    '0 0 14 * * *',
+    removeMarrainageForExpiredUsers,
+    null,
+    true,
+    'Europe/Paris',
+  );
+} else {
+  console.log('❌ The job removeMarrainageForExpiredUsers is OFF');
 }

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -97,6 +97,7 @@ if (config.featureRemoveMarrainageForExpiredUsers) {
   const removeMarrainage = new CronJob(
     '0 0 14 * * *',
     removeMarrainageForExpiredUsers,
+  );
 } else {
   console.log('❌ The job removeMarrainageForExpiredUsers is OFF');
 }

--- a/src/schedulers/cron.js
+++ b/src/schedulers/cron.js
@@ -90,7 +90,6 @@ if (config.featureOnUserContractEnd) {
   console.log('Send contract ending message job is off');
 }
 
-
 if (config.featureRemoveMarrainageForExpiredUsers) {
   console.log('Create cron job for removing marrainage for expired users');
   const { removeMarrainageForExpiredUsers } = require('./marrainageScheduler');

--- a/src/schedulers/marrainageScheduler.js
+++ b/src/schedulers/marrainageScheduler.js
@@ -34,12 +34,12 @@ module.exports.removeMarrainageForExpiredUsers = async () => {
 
   expiredUsers.forEach(async (user) => {
     await knex('marrainage')
-    .where({ last_onboarder: user.id})
-    .update({ completed: false})
-    console.log(`Le marrainage de ${user.fullname} a pris fin suite à son départ.`)
+    .where({ last_onboarder: user.id })
+    .update({ completed: false });
+    console.log(`Le marrainage de ${user.fullname} a pris fin suite à son départ.`);
   });
   return expiredUsers;
-}
+};
 
 module.exports.reloadMarrainageJob = new CronJob(
   '0 0 10 * * 1-5', // monday through friday at 10:00:00

--- a/src/scripts/removeMarrainageForExpiredUsers.js
+++ b/src/scripts/removeMarrainageForExpiredUsers.js
@@ -1,0 +1,3 @@
+const { removeMarrainageForExpiredUsers } = require('../schedulers/marrainageScheduler');
+
+removeMarrainageForExpiredUsers();

--- a/tests/test-marrainage.ts
+++ b/tests/test-marrainage.ts
@@ -361,7 +361,7 @@ describe('Marrainage', () => {
       },
     ];
 
-    const url = process.env.USERS_API
+    const url = config.usersAPI;
     nock(url)
       .get((uri) => uri.includes('authors.json'))
       .reply(200, betaUsers)


### PR DESCRIPTION
Checker les personnes expirées, et le retrouver dans la table marrainage, avec un filtre sur les  `last_onboarder`. On passe ensuite le `completed` a false. 

Le job existant `reloadMarrainage` ayant déjà un filtre sur les `completed`a false se relancera pour trouver un.e autre marrain.e pour la personne marrainée.