### PR TITLE
Fix le get github file, en récupérant le fichier sur le repo principal beta.gouv.fr et non le fork

### DIFF
--- a/src/controllers/utils.ts
+++ b/src/controllers/utils.ts
@@ -264,7 +264,7 @@ export function deleteGithubBranch(branch) {
 }
 
 export function getGithubFile(path, branch) {
-  const url = `https://api.github.com/repos/${config.githubFork}/contents/${path}`;
+  const url = `https://api.github.com/repos/${config.githubRepository}/contents/${path}`;
 
   return requestWithAuth(`GET ${url}`, { branch });
 };


### PR DESCRIPTION
Le fork n'est pas à jour avec le repo principal, donc le get file renvoie une 404 dans certain cas.