### PR TITLE
N'envoie pas l'email d'invitation mattermost si la création de l'utilisateur n'a pas marché

### DIFF
--- a/src/lib/mattermost.ts
+++ b/src/lib/mattermost.ts
@@ -192,13 +192,7 @@ export async function createUser({ email, username, password }, teamId = null) {
       )
       .then((response) => response.data);
   } catch (err) {
-    console.error(
-      "Erreur d'ajout des utilisateurs à mattermost",
-      err,
-      email,
-      username
-    );
-    return;
+    throw new Error(`Erreur d'ajout de l'utilisateurs ${username} à mattermost : ${err}`)
   }
   console.log("Ajout de l'utilisateur", email, username);
   return res;

--- a/src/schedulers/mattermostScheduler.ts
+++ b/src/schedulers/mattermostScheduler.ts
@@ -160,17 +160,23 @@ export async function createUsersByEmail() {
     activeGithubUsersUnregisteredOnMattermost.map(async (user) => {
       const email = utils.buildBetaEmail(user.id);
       const password = crypto.randomBytes(20).toString('base64').slice(0, -2);
-      await mattermost.createUser({
-        email,
-        username: user.id,
-        // mattermost spec : password must contain at least 20 characters
-        password,
-      });
+      try {
+        await mattermost.createUser({
+          email,
+          username: user.id,
+          // mattermost spec : password must contain at least 20 characters
+          password,
+        });
 
-      const html = await ejs.renderFile('./views/emails/mattermost.ejs', {
-        resetPasswordLink: 'https://mattermost.incubateur.net/reset_password',
-      });
-      await utils.sendMail(email, 'Inscription à mattermost', html);
+        const html = await ejs.renderFile('./views/emails/mattermost.ejs', {
+          resetPasswordLink: 'https://mattermost.incubateur.net/reset_password',
+        });
+        await utils.sendMail(email, 'Inscription à mattermost', html);
+      } catch (err) {
+        console.error(
+          "Erreur d'ajout des utilisateurs à mattermost", err
+        );
+      }
     })
   );
   return results;


### PR DESCRIPTION
Aujourd'hui si la creation de l'utilisateur mattermost plante (ie: username already existe), l'email d'invitation est quand même envoyé