### PR TITLE
Fix des urls cassés par l'utilisation des users en db au lieu des users de l'api beta

### DIFF
--- a/src/models/dbUser.ts
+++ b/src/models/dbUser.ts
@@ -6,10 +6,12 @@ export interface DBUser {
     created_at: Date;
 }
 
-export interface DBUserWithMattermostUsername {
+export interface DBUserExtendedWithGithubAndMattermostInfo {
     secondary_email: string;
     primary_email: string;
     username: string;
     created_at: Date;
     mattermostUsername: string;
+    fullname: string;
+    id: string;
 }

--- a/src/models/dbUser.ts
+++ b/src/models/dbUser.ts
@@ -5,13 +5,3 @@ export interface DBUser {
     username: string;
     created_at: Date;
 }
-
-export interface DBUserExtendedWithGithubAndMattermostInfo {
-    secondary_email: string;
-    primary_email: string;
-    username: string;
-    created_at: Date;
-    mattermostUsername: string;
-    fullname: string;
-    id: string;
-}

--- a/src/models/member.ts
+++ b/src/models/member.ts
@@ -22,11 +22,15 @@ export interface Member {
   end: string;
   employer: string;
   domaine: Domaine;
-  mattermostUsername?: string;
 }
 
 export interface MemberWithPrimaryEmail extends Member {
   primary_email: string;
+}
+
+export interface MemberWithPrimaryEmailAndMattermostUsername extends Member {
+  primary_email: string;
+  mattermostUsername: string;
 }
 
 export interface MemberWithPermission {

--- a/src/schedulers/userContractEndingScheduler.ts
+++ b/src/schedulers/userContractEndingScheduler.ts
@@ -4,7 +4,7 @@ import * as utils from '../controllers/utils';
 import knex from '../db';
 import * as mattermost from '../lib/mattermost';
 import { renderHtmlFromMd } from '../lib/mdtohtml';
-import { DBUser, DBUserWithMattermostUsername } from '../models/dbUser';
+import { DBUser, DBUserExtendedWithGithubAndMattermostInfo } from '../models/dbUser';
 import { Member } from '../models/member';
 import betagouv from '../betagouv';
 
@@ -14,7 +14,7 @@ interface MessageConfig {
 }
 
 // get users that are member (got a github card) and mattermost account that is not in the team
-const getRegisteredUsersWithEndingContractInXDays =  async (days) : Promise<DBUserWithMattermostUsername[]> => {
+const getRegisteredUsersWithEndingContractInXDays =  async (days) : Promise<DBUserExtendedWithGithubAndMattermostInfo[]> => {
   const allMattermostUsers = await mattermost.getUserWithParams();
   const users = await BetaGouv.usersInfos();
   const activeGithubUsers = users.filter((user) => {
@@ -43,15 +43,18 @@ const getRegisteredUsersWithEndingContractInXDays =  async (days) : Promise<DBUs
       const index = allMattermostUsersEmails.indexOf(
         user.primary_email
       );
+      const githubUser = activeGithubUsers.find(ghUser => ghUser.id === user.username)
       return {
         ...user,
+        fullname: githubUser.fullname,
+        id: githubUser.id,
         mattermostUsername: index > -1 ? allMattermostUsers[index].username : undefined,
       };
     }
   );
   return registeredUsersWithEndingContractInXDays.filter(
     (user) => user.mattermostUsername
-  ) as DBUserWithMattermostUsername[];
+  ) as DBUserExtendedWithGithubAndMattermostInfo[];
 };
 
 const CONFIG_MESSAGE = {
@@ -70,7 +73,7 @@ const EMAIL_FILES = {
   'j+30': 'mailExpired30days',
 };
 
-const sendMessageOnChatAndEmail = async (user: DBUserWithMattermostUsername, messageConfig: MessageConfig) => {
+const sendMessageOnChatAndEmail = async (user: DBUserExtendedWithGithubAndMattermostInfo, messageConfig: MessageConfig) => {
   const messageContent = await ejs.renderFile(
     `./views/emails/${messageConfig.emailFile}`,
     {
@@ -110,7 +113,7 @@ export async function sendContractEndingMessageToUsers(
 ) {
   console.log('Run send contract ending message to users');
   const messageConfig = CONFIG_MESSAGE[configName];
-  let registeredUsersWithEndingContractInXDays : DBUserWithMattermostUsername[];
+  let registeredUsersWithEndingContractInXDays : DBUserExtendedWithGithubAndMattermostInfo[];
   if (users) {
     registeredUsersWithEndingContractInXDays = users;
   } else {

--- a/views/emails/mail2days.ejs
+++ b/views/emails/mail2days.ejs
@@ -3,8 +3,8 @@ Bonjour <%= user.fullname %> !
 Ton départ de la communauté beta.gouv.fr est prévu pour dans 2 jours (le <%= user.end %>). Si cette date a changé, mets-là à jour pour rester membre de la communauté.
 
 Pour mettre à jour ta date de fin de mission, tu peux : 
-- [modifier ta fiche sur Github](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/<%= user.username %>.md)
-- [utiliser l'interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/<%= user.username %>)
+- [modifier ta fiche sur Github](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/<%= user.id %>.md)
+- [utiliser l'interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/<%= user.id %>)
 - [suivre la documentation](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA)
 
 Si tu as besoin d'aide, n'hésite pas à répondre [par email à secretariat@incubateur.net](mailto:secretariat@incubateur.net) ou à poser tes questions sur Mattermost dans [~incubateur-secretaria](https://mattermost.incubateur.net/betagouv/channels/incubateur-secretaria)

--- a/views/emails/mail2days.ejs
+++ b/views/emails/mail2days.ejs
@@ -3,8 +3,8 @@ Bonjour <%= user.fullname %> !
 Ton départ de la communauté beta.gouv.fr est prévu pour dans 2 jours (le <%= user.end %>). Si cette date a changé, mets-là à jour pour rester membre de la communauté.
 
 Pour mettre à jour ta date de fin de mission, tu peux : 
-- [modifier ta fiche sur Github](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/<%= user.id %>.md)
-- [utiliser l'interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/<%= user.id %>)
+- [modifier ta fiche sur Github](https://github.com/betagouv/beta.gouv.fr/edit/master/content/_authors/<%= user.username %>.md)
+- [utiliser l'interface en ligne](https://beta.gouv.fr/admin/#/collections/authors/entries/<%= user.username %>)
 - [suivre la documentation](https://pad.incubateur.net/xAj0p9RKTPW00RUGJHtbyA)
 
 Si tu as besoin d'aide, n'hésite pas à répondre [par email à secretariat@incubateur.net](mailto:secretariat@incubateur.net) ou à poser tes questions sur Mattermost dans [~incubateur-secretaria](https://mattermost.incubateur.net/betagouv/channels/incubateur-secretaria)


### PR DESCRIPTION
Les liens dans les messages invitant à mettre la date à jour sont cassés suite au changement primary_email. 
=> Les utilisateurs sont maintenant récupérer depuis la DB, et non depuis les fiches github, il manque donc la property `fullname` et `id`.

https://github.com/betagouv/secretariat/commit/fa29d2c4a49e137f9393ab9bc182960872210814#diff-6ccd9085631a0b0bb47ffd105c51010491404c0a82c8607016a213e1915939a0L12

Une solution qui aurait pu permettre d'anticiper ce problème serait d'avoir un rendu front avec un type check.
