### PR TITLE
Change le jour d'activation du cron sur une base moins régulière

### DIFF
--- a/src/schedulers/cron.ts
+++ b/src/schedulers/cron.ts
@@ -177,7 +177,7 @@ const jobs: Job[] = [
     description: 'Cron job to create user on mattermost by email',
   },
   {
-    cronTime: '0 */4 * * * *',
+    cronTime: '0 0 10 * * 0',
     onTick: addUsersNotInCommunityToCommunityTeam,
     isActive: !!config.featureAddUserToCommunityTeam,
     name: 'addUsersNotInCommunityToCommunityTeam',


### PR DESCRIPTION
Le cron tournait trop souvent alors qu'il n'est plus vraiment utile à part pour des edges cases.