### PR TITLE
Rendre les messages des e-mails de départ j-30/j-15 moins angoissants

### DIFF
--- a/src/views/templates/emails/mail15days.ejs
+++ b/src/views/templates/emails/mail15days.ejs
@@ -1,20 +1,21 @@
 Bonjour <%= user.fullname %> !  
 
-Ton départ de la communauté beta.gouv.fr est prévu pour dans 15 jours (le <%= user.end %>). 
+Un petit mot pour te rappeler que lorsque ta fiche de membre chez beta.gouv.fr a été créée ou mise-à-jour, ta date de fin de mission a été définie pour le <%= user.end %>. Cette date est pour bientôt !
 
-Si cette date a changé, mets la à jour pour rester membre de la communauté. C'est important car elle permet de conserver tes accès au différents services : mattermost, emails, ...
+Si la date est incorrecte (tu l’avais peut-être mis sans avoir d’info sur la date réelle de fin, ou alors la date de fin a été revue), mets la à jour sur le secrétariat. C'est important car elle permet de conserver tes accès au différents services : mattermost, emails, ...
 
-En général, ta nouvelle date de fin doit correspondre à la date du prochain comité d'investissement de ton produit (dans 6 mois maximum).
-
-Pour mettre à jour ta date de fin de mission, tu peux : 
+Pour faire cette mise à jour, tu peux : 
 - la modifier en te connectant au [secretariat](https://secretariat.incubateur.net/account#update-end-date)
 - [suivre les autres méthodes de modification de ta fiche](https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/outils/mise-a-jour-de-mes-informations)
+
+En général, ta nouvelle date de fin doit correspondre à la date du prochain comité d'investissement de ton produit (dans 6 mois maximum).
 
 Si tu n'y arrives pas un membre de ton équipe pourra sans doute t'aider.
 Sinon n'hésite pas à poser tes questions sur Mattermost dans [~incubateur-help](https://mattermost.incubateur.net/betagouv/channels/incubateur-help) ou à répondre [par email à secretariat@incubateur.net](mailto:secretariat@incubateur.net).
 
+
 <% if (jobs.length) { %>
-Si ta mission se termine, voici quelques offres actuellements ouvertes qui pourraient correspondre à ton domaine :
+Si la date est correcte et que ta mission se termine, voici quelques offres actuellements ouvertes qui pourraient correspondre à ton domaine :
 <% for (var i =0; i < jobs.length;  i++ ) { %>
 - [<%= jobs[i].title.trim() %>](<%= jobs[i].url %>)
 <% } %>
@@ -22,7 +23,7 @@ Tu peux retrouver toutes les offres ici : [https://beta.gouv.fr/](https://beta.g
 <% } %>
 
 <% if (!jobs.length) { %>   
-Si ta mission se termine, tu peux retrouver toutes les offres ici : [https://beta.gouv.fr/](https://beta.gouv.fr/)
+Si la date est correcte et que ta mission se termine, tu peux retrouver toutes les offres ici : [https://beta.gouv.fr/](https://beta.gouv.fr/)
 <% } %>
 
 Tu peux aussi proposer une candidature spontanée : 

--- a/src/views/templates/emails/mail30days.ejs
+++ b/src/views/templates/emails/mail30days.ejs
@@ -1,12 +1,11 @@
 Bonjour <%= user.fullname %> !  
 
-Ton départ de la communauté beta.gouv.fr est prévu pour dans 30 jours (le <%= user.end %>). 
+Un petit mot pour te rappeler que lorsque ta fiche de membre chez beta.gouv.fr a été créée ou mise-à-jour, ta date de fin de mission a été définie pour le <%= user.end %>. Cette date est pour bientôt !
 
-Si cette date a changé, met la à jour pour rester membre de la communauté :
-[secretariat](https://secretariat.incubateur.net/account#update-end-date)
+Si la date est incorrecte (tu l’avais peut-être mis sans avoir d’info sur la date réelle de fin, ou alors la date de fin a été revue), [mets-la à jour](https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/outils/mise-a-jour-de-mes-informations#comment-mettre-a-jour-mes-dates-de-mission) sur la page du [secretariat](https://secretariat.incubateur.net/account#update-end-date) pour rester membre de la communauté.
 
 <% if (jobs.length) { %>
-Si ta mission se termine, voici quelques offres actuellements ouvertes qui pourraient correspondre à ton domaine :
+Si la date est correcte et que ta mission se termine, voici quelques offres actuellements ouvertes qui pourraient correspondre à ton domaine :
 <% for (var i =0; i < jobs.length;  i++ ) { %>
 - [<%= jobs[i].title.trim() %>](<%= jobs[i].url %>)
 <% } %>
@@ -17,7 +16,7 @@ Tu peux retrouver toutes les offres ici : [https://beta.gouv.fr/](https://beta.g
 
 
 <% if (!jobs.length) { %>   
-Si ta mission se termine, tu peux retrouver toutes les offres ici : [https://beta.gouv.fr/](https://beta.gouv.fr/)
+Si la date est correcte et que ta mission se termine, tu peux retrouver toutes les offres ici : [https://beta.gouv.fr/](https://beta.gouv.fr/)
 <% } %>
 
 Tu peux aussi proposer une candidature spontanée : 

--- a/src/views/templates/emails/mailExpired1day.ejs
+++ b/src/views/templates/emails/mailExpired1day.ejs
@@ -15,7 +15,7 @@ Pour continuer à échanger avec la communauté sur Mattermost, dans l'espace d�
 - Remplacer ton email beta par ton adresse pro/perso
 - Valider cette nouvelle adresse en cliquant sur le lien de validation qui lui sera envoyé
 
-S'il s'agit d'un oublie et que tu es toujours dans la communauté suis la procédure suivante :
+S'il s'agit d'un oubli et que tu es toujours dans la communauté, suis la procédure suivante :
 https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/emails/depannage-je-nai-plus-acces-a-mon-mail
 
 Si tu as besoin d'aide, n'hésite pas à répondre à ce mail.

--- a/src/views/templates/emails/mailExpired30days.ejs
+++ b/src/views/templates/emails/mailExpired30days.ejs
@@ -1,8 +1,10 @@
 Bonjour <%= user.fullname %> !
 
-Ta mission chez beta.gouv.fr est terminée. Tes différents comptes relatif à la communauté vont bientôt être supprimés ou désactivés.
+Un petit mot pour te rappeler que lorsque ta fiche de membre chez beta.gouv.fr a été créée ou mise-à-jour, ta date de fin de mission a été définie pour le <%= user.end %>. Cette date est pour bientôt ! Tes différents comptes relatif à la communauté seront alors supprimés ou désactivés.
 
-De ton côté, tu peux :
+Si la date est incorrecte (tu l’avais peut-être mis sans avoir d’info sur la date réelle de fin, ou alors la date de fin a été revue), [mets-la à jour](https://doc.incubateur.net/communaute/travailler-a-beta-gouv/jutilise-les-outils-de-la-communaute/outils/mise-a-jour-de-mes-informations#comment-mettre-a-jour-mes-dates-de-mission) pour rester membre de la communauté.
+
+Si la date est correcte et que ta mission se termine, tu peux déjà :
 - Te retirer les droits d’écriture de l’[agenda public de l’incubateur](https://calendar.google.com/calendar/embed?src=0ieonqap1r5jeal5ugeuhoovlg%40group.calendar.google.com&ctz=Europe/Paris).
 - Supprimer ton compte Mattermost si tu ne comptes plus être actif ou changer l'adresse email de ton compte (l'adresse beta.gouv.fr va être supprimée)
 


### PR DESCRIPTION
Nouveaux wording évoqués dans des [discussions sur Mattermost](https://mattermost.incubateur.net/betagouv/pl/7bf1df4qw3899y7ykurk6n7wqo)

L'idée est de rendre ça moins angoissant pour des gens dont la date est "fausse"