### PR TITLE
Correction cron d'ajout des membres dans communauté mattermost

### DIFF
--- a/src/schedulers/cron.ts
+++ b/src/schedulers/cron.ts
@@ -217,7 +217,7 @@ const jobs: Job[] = [
     description: 'Cron job to create user on mattermost by email',
   },
   {
-    cronTime: '0 0 10 * * 0',
+    cronTime: '0 0 10 * * *',
     onTick: addUsersNotInCommunityToCommunityTeam,
     isActive: !!config.featureAddUserToCommunityTeam,
     name: 'addUsersNotInCommunityToCommunityTeam',


### PR DESCRIPTION
Il semble y avoir une erreur le cron tourne les dimanches à 10h, tu ne voulais pas le lancer tous les jours ?