### PR TITLE
Permettre la création directe de comptes Exchange/OVH pour les personnes qui rejoignent des startups au sein d'incubateurs ou structures utilisant le compte Exchange de BetaGouv

### DIFF
--- a/src/betagouv.ts
+++ b/src/betagouv.ts
@@ -221,7 +221,9 @@ const betaOVH = {
     if (config.OVH_EMAIL_EXCHANGE_NAME) {
       const urlExchange = `/email/exchange/${config.OVH_EMAIL_EXCHANGE_NAME}/service/${config.OVH_EMAIL_EXCHANGE_NAME}/account`
       promises.push(
-        ovh.requestPromised('GET', urlExchange, {}).then(data => data.map(d => d.split('@')[0])).catch(e => [])
+        ovh.requestPromised('GET', urlExchange, { primaryEmailAddress: `%@${config.domain}` })
+          .then(data => data.map(d => d.split('@')[0]))
+          .catch(e => [])
       )
     }
     try {

--- a/src/betagouv.ts
+++ b/src/betagouv.ts
@@ -39,11 +39,11 @@ export interface OvhResponder {
 }
 
 export interface OvhExchangeCreationData {
-  firstName: string;
-  lastName: string;
-  displayName: string;
-  initial: string;
-  company: string;
+  firstName?: string;
+  lastName?: string;
+  displayName?: string;
+  initial?: string;
+  company?: string;
 }
 
 const betaGouv = {

--- a/src/scripts/createEmailForExchange.ts
+++ b/src/scripts/createEmailForExchange.ts
@@ -1,0 +1,13 @@
+import BetaGouv from "../betagouv";
+
+async function main() {
+  if (process.argv.length < 3) {
+    console.error(`Usage: ${process.argv[1]} id-to-create '{ "company":... }'`);
+    process.exit(1);
+  }
+  const idToCreate = process.argv[2];
+  const creationData = process.argv[3] ? JSON.parse(process.argv[3]) : {};
+  await BetaGouv.createEmailForExchange(idToCreate, creationData);
+}
+
+main().catch(console.error);

--- a/src/scripts/deleteEmailForExchange.ts
+++ b/src/scripts/deleteEmailForExchange.ts
@@ -1,0 +1,12 @@
+import BetaGouv from "../betagouv";
+
+async function main() {
+  if (process.argv.length !== 3) {
+    console.error(`Usage: ${process.argv[1]} id-to-delete`);
+    process.exit(1);
+  }
+  const idToDelete = process.argv[2];
+  return await BetaGouv.deleteEmailForExchange(idToDelete);
+}
+
+main().then(console.log, console.error);

--- a/tests/test-user.ts
+++ b/tests/test-user.ts
@@ -1089,6 +1089,7 @@ describe('User', () => {
       utils.mockOvhRedirections();
       utils.mockOvhUserResponder();
       utils.mockOvhUserEmailInfos();
+      utils.mockStartups();
 
       const newMember = testUsers.find((user) => user.id === 'membre.nouveau');
       const allAccountsExceptANewMember = testUsers.filter(
@@ -1380,7 +1381,7 @@ describe('User', () => {
           [
             {
               id: 'membre.nouveau-email',
-              fullname: 'membre Nouveau test email',
+              fullname: 'Membre Nouveau test email',
               startups: [
                 "itou",
                 "missing-startup",
@@ -1400,7 +1401,15 @@ describe('User', () => {
 
         await createEmail('membre.nouveau-email', 'Test');
 
-        Betagouv.createEmailForExchange.calledWith('membre.nouveau-email').should.be.true;
+        Betagouv.createEmailForExchange.firstCall.args.should.deep.equal(
+          [
+            'membre.nouveau-email',
+            {
+              displayName: 'Membre Nouveau test email',
+              firstName: 'Membre',
+              lastName: 'Nouveau test email',
+            }
+          ]);
       });
     });
 

--- a/tests/test-user.ts
+++ b/tests/test-user.ts
@@ -1353,5 +1353,58 @@ describe('User', () => {
       Betagouv.createEmail.calledWith('membre.nouveau-email').should.be.true;
     });
 
+    context('when the user needs an Exchange account', ()=> {
+      beforeEach(async () => {
+        utils.cleanMocks();
+
+        sandbox.stub(Betagouv, 'createEmailForExchange');
+
+        sandbox.stub(Betagouv, 'startupsInfos').resolves(
+          [
+            {
+              "type": "startup",
+              "id": "itou",
+              "attributes": {
+                "name": "Itou",
+              },
+              "relationships": {
+                "incubator": {
+                  "data": {
+                    "type": "incubator",
+                    "id": "gip-inclusion"
+                  }
+                }
+              },
+            }
+          ]
+        );
+
+        sandbox.stub(Betagouv, 'usersInfos').resolves(
+          [
+            {
+              id: 'membre.nouveau-email',
+              fullname: 'membre Nouveau test email',
+              startups: [
+                "itou"
+              ],
+            },
+          ]
+        );
+      });
+
+      it('should create an Exchange email account', async () => {
+        await knex('users').insert({
+          username: 'membre.nouveau-email',
+          primary_email: null,
+          primary_email_status: EmailStatusCode.EMAIL_UNSET,
+          secondary_email: 'membre.nouveau-email.perso@example.com',
+        });
+
+        await createEmail('membre.nouveau-email', 'Test');
+
+        Betagouv.createEmailForExchange.calledWith('membre.nouveau-email').should.be.true;
+      });
+    });
+
   });
 });

--- a/tests/test-user.ts
+++ b/tests/test-user.ts
@@ -69,7 +69,7 @@ describe('User', () => {
             .send({
               to_email: 'test@example.com',
             })
-          
+
           const res = await knex('users').where({ username: 'membre.nouveau'}).first()
           res.primary_email.should.equal(`membre.nouveau@${config.domain}`)
           ovhEmailCreation.isDone().should.be.true;
@@ -252,7 +252,7 @@ describe('User', () => {
             .send({
               to_email: 'test@example.com',
             })
-          
+
           const res = await knex('users').where({ username: 'membre.nouveau'}).first()
           res.primary_email.should.equal(`membre.nouveau@${config.domain}`)
           ovhEmailCreation.isDone().should.be.true;
@@ -312,7 +312,7 @@ describe('User', () => {
 
   describe('POST /users/:username/redirections authenticated', () => {
     let getToken
-    
+
     beforeEach(() => {
       getToken = sinon.stub(session, 'getToken')
       getToken.returns(utils.getJWT('membre.actif'))
@@ -391,7 +391,7 @@ describe('User', () => {
 
   describe('POST /users/:username/redirections/:email/delete authenticated', () => {
     let getToken
-    
+
     beforeEach(() => {
       getToken = sinon.stub(session, 'getToken')
       getToken.returns(utils.getJWT('membre.actif'))
@@ -480,7 +480,7 @@ describe('User', () => {
 
   describe('POST /users/:username/password authenticated', () => {
     let getToken
-    
+
     beforeEach(() => {
       getToken = sinon.stub(session, 'getToken')
       getToken.returns(utils.getJWT('membre.actif'))
@@ -659,7 +659,7 @@ describe('User', () => {
 
   describe('POST /user/:username/email/delete', () => {
     let getToken
-    
+
     beforeEach(() => {
       getToken = sinon.stub(session, 'getToken')
       getToken.returns(utils.getJWT('membre.actif'))
@@ -687,7 +687,7 @@ describe('User', () => {
       const expectedRedirectionBody = (body) => {
         return body.from === `membre.actif@${config.domain}` && body.to === config.leavesEmail;
       }
-      
+
       const ovhRedirectionDepartureEmail = nock(/.*ovh.com/)
         .post(/^.*email\/domain\/.*\/redirection/, expectedRedirectionBody)
         .reply(200);
@@ -704,7 +704,7 @@ describe('User', () => {
 
   describe('POST /users/:username/secondary_email', () => {
     let getToken
-    
+
     beforeEach((done) => {
       getToken = sinon.stub(session, 'getToken')
       getToken.returns(utils.getJWT('membre.nouveau'))
@@ -899,7 +899,7 @@ describe('User', () => {
 
   describe('POST /users/:username/redirections/:email/delete authenticated', () => {
     let getToken
-    
+
     beforeEach(() => {
       getToken = sinon.stub(session, 'getToken')
       getToken.returns(utils.getJWT('membre.actif'))
@@ -1039,7 +1039,7 @@ describe('User', () => {
           done();
         });
     });
-  }); 
+  });
 
   describe('cronjob', () => {
     before(async () => {
@@ -1277,12 +1277,12 @@ describe('User', () => {
       utils.mockOvhRedirections();
       utils.mockOvhUserResponder();
       utils.mockOvhUserEmailInfos();
-  
+
       const newMember = testUsers.find((user) => user.id === 'membre.nouveau');
       const allAccountsExceptANewMember = testUsers.filter(
         (user) => user.id !== newMember.id
       );
-  
+
       nock(/.*ovh.com/)
         .get(/^.*email\/domain\/.*\/redirection/)
         .reply(
@@ -1298,7 +1298,7 @@ describe('User', () => {
       const ovhRedirectionCreation = nock(/.*ovh.com/)
         .post(/^.*email\/domain\/.*\/redirection/)
         .reply(200);
-  
+
       await knex('login_tokens').truncate()
       await knex('users').where({
         username: newMember.id,
@@ -1331,6 +1331,7 @@ describe('User', () => {
 
     beforeEach(async () => {
       sandbox.stub(Betagouv, 'createEmail');
+      sandbox.stub(Betagouv, 'createEmailForExchange');
       sandbox.stub(Betagouv, 'sendInfoToChat');
     });
 
@@ -1355,10 +1356,6 @@ describe('User', () => {
 
     context('when the user needs an Exchange account', ()=> {
       beforeEach(async () => {
-        utils.cleanMocks();
-
-        sandbox.stub(Betagouv, 'createEmailForExchange');
-
         sandbox.stub(Betagouv, 'startupsInfos').resolves(
           [
             {
@@ -1385,7 +1382,8 @@ describe('User', () => {
               id: 'membre.nouveau-email',
               fullname: 'membre Nouveau test email',
               startups: [
-                "itou"
+                "itou",
+                "missing-startup",
               ],
             },
           ]


### PR DESCRIPTION
### 🍣 Problème 

Lorsque quelqu'un·e rejoint le GIP de la Plateforme de l'inclusion, qui a décidé d'être pilote au sein de BetaGouv pour tester Exchange à grande échelle, il (ou elle) doit voir son compte migré quelques temps après.

La manipulation en soi n'est pas si compliquée mais la procédure au global : 
- induit du temps
- …et de la complication (inutiles)
- dépend exclusivement d'un des administrateurs du domaine, en l'occurrence @jbuget 
- ce qui dégrade l'expérience d'accueil des nouvelles et nouveaux

### 🦄 Solution

Après avoir échagné avec pas mal de monde, en particulier de chez BetaGouv, il a été acté de modifier l'application Secrétariat pour faire en sorte que les gens qui rejoignent le domaine `beta.gouv.fr` via le formulaire d'inscription BetaGouv, si parmi la ou les SE qu'ils indiquent l'une d'entre elle est portée par un incubateur basé sur Exchange, alors on lui crée un compte Exchange directement via l'API dédiée sur OVH plutôt qu'un compte MX Basic, qu'il faut ensuite faire migrer.

### 👾 Réalisation

Pour ce faire, il faut consommer un nouveau endpoint de l'API OVH.

Nous avons fait en sorte d'ajouter le minimum de code (en vert), à l'endroit le plus mutualisé cf. schéma ci-dessous.

<img width="751" alt="secretariat_create_email" src="https://github.com/betagouv/secretariat/assets/265963/c929cb32-23d7-477e-8941-b58c579e1272">

### 🔨 Validation

Pour tester, il faut : 
1. lancer l'application en local
1. afficher le formulaire d'inscription
1. quand on valide le formulaire, une PR doit être ouverte sur le repo cible
1. quand on fusionne la PR, ça doit affecter l'un des comptes Exchange à l'email `prenom.nom@beta.gouv` déduit du formulaire
1. de fait, il doit y a voir une adresse en `xxx@configureme.me` de moins dans la liste des emails Exchange

### Informations

Cette PR embarque aussi 2 scripts Node.js exécutables à la main : 
- création d'un compte Exchange direct
- désaffection (ou "réinitiatlisation" dans le langage OVH), d'un compte Exchange